### PR TITLE
Add account management UI and secure profile APIs

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import Navbar from './Navbar';
+import React from "react";
+import Navbar from "./Navbar";
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <>
+    <div className="min-h-screen bg-slate-50">
         <Navbar />
-        <main style={{ padding: '20px' }}>{children}</main>
-    </>
+        <main className="px-4 py-8 sm:px-6 lg:px-8">{children}</main>
+    </div>
 );
 
 export default Layout;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,13 +1,23 @@
-import Link from 'next/link';
+import Link from "next/link";
 
 const Navbar: React.FC = () => (
-    <nav style={{ padding: '10px', background: '#333', color: '#fff' }}>
-        <Link href="/render" style={{ marginRight: '10px', color: '#fff' }}>
-            Render
-        </Link>
-        <Link href="/login" style={{ color: '#fff' }}>
-            Login
-        </Link>
+    <nav className="bg-white border-b">
+        <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
+            <Link href="/" className="text-lg font-semibold text-emerald-600">
+                FoodieGo
+            </Link>
+            <div className="flex items-center gap-2 text-sm text-gray-700">
+                <Link href="/render" className="px-3 py-2 rounded-lg hover:bg-gray-100">
+                    Render
+                </Link>
+                <Link href="/account" className="px-3 py-2 rounded-lg hover:bg-gray-100">
+                    Account
+                </Link>
+                <Link href="/login" className="px-3 py-2 rounded-lg hover:bg-gray-100">
+                    Login
+                </Link>
+            </div>
+        </div>
     </nav>
 );
 

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -1,0 +1,261 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import Layout from "@components/Layout";
+import axios from "@utils/apiClient";
+import { auth, makeRecaptcha } from "@utils/firebaseClient";
+import { useAppDispatch } from "@store/index";
+import { logout, setTokens } from "@store/authSlice";
+import { linkWithPhoneNumber, signOut, updateEmail } from "firebase/auth";
+
+type Me = {
+    id: number;
+    email: string | null;
+    phone: string | null;
+    provider: string | null;
+    is_email_verified: boolean;
+    is_phone_verified: boolean;
+};
+
+function Chip({ ok, label }: { ok: boolean; label: string }) {
+    return (
+        <span
+            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                ok ? "bg-green-100 text-green-800" : "bg-yellow-100 text-yellow-800"
+            }`}
+        >
+            {label}
+        </span>
+    );
+}
+
+export default function AccountPage() {
+    const dispatch = useAppDispatch();
+    const [me, setMe] = useState<Me | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [msg, setMsg] = useState<string>("");
+    const [err, setErr] = useState<string>("");
+
+    // change email
+    const [newEmail, setNewEmail] = useState("");
+    // phone link
+    const [phone, setPhone] = useState("");
+    const [otp, setOtp] = useState("");
+    const confirmRef = useRef<any>(null);
+
+    const providerLabel = useMemo(() => {
+        if (!me?.provider) return "-";
+        return me.provider;
+    }, [me]);
+
+    async function fetchMe() {
+        setLoading(true);
+        setErr("");
+        setMsg("");
+        try {
+            const r = await axios.get("/api/user/me");
+            setMe(r.data.user);
+        } catch (e: any) {
+            setErr(e?.response?.data?.error || e?.message || "Failed to load profile");
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        fetchMe();
+    }, []);
+
+    async function resendVerifyEmail() {
+        setErr("");
+        setMsg("");
+        try {
+            const idToken = await auth.currentUser?.getIdToken(true);
+            if (!idToken) throw new Error("No firebase session; please re-login");
+            await axios.post("/api/user/send-verify-email", { idToken });
+            setMsg("Verification email sent.");
+        } catch (e: any) {
+            setErr(e?.response?.data?.error || e?.message || "Failed to send verification email");
+        }
+    }
+
+    async function onChangeEmail() {
+        setErr("");
+        setMsg("");
+        try {
+            if (!newEmail) throw new Error("New email required");
+            if (!auth.currentUser) throw new Error("No firebase session; please re-login");
+            await updateEmail(auth.currentUser, newEmail);
+            const idToken = await auth.currentUser.getIdToken(true);
+            const r = await axios.post("/api/login", { idToken });
+            dispatch(setTokens({ accessToken: r.data.accessToken, refreshToken: r.data.refreshToken }));
+            setMsg("Email updated. If required, please verify via email.");
+            setNewEmail("");
+            await fetchMe();
+        } catch (e: any) {
+            setErr(e?.code || e?.message || "Failed to update email");
+        }
+    }
+
+    async function onPhoneSendOtp() {
+        setErr("");
+        setMsg("");
+        try {
+            if (!phone) throw new Error("Phone number required");
+            if (!auth.currentUser) throw new Error("Please login again");
+            const verifier = makeRecaptcha("btn-send-otp");
+            const confirmation = await linkWithPhoneNumber(auth.currentUser, phone, verifier);
+            confirmRef.current = confirmation;
+            setMsg("OTP sent to your phone.");
+            setOtp("");
+        } catch (e: any) {
+            setErr(e?.code || e?.message || "Failed to send OTP");
+        }
+    }
+
+    async function onPhoneConfirmOtp() {
+        setErr("");
+        setMsg("");
+        try {
+            const confirmation = confirmRef.current;
+            if (!confirmation) throw new Error("No OTP session. Send OTP first.");
+            if (!otp) throw new Error("Enter the OTP");
+            await confirmation.confirm(otp);
+            const idToken = await auth.currentUser?.getIdToken(true);
+            if (!idToken) throw new Error("No firebase session after phone link");
+            const r = await axios.post("/api/login", { idToken });
+            dispatch(setTokens({ accessToken: r.data.accessToken, refreshToken: r.data.refreshToken }));
+            setMsg("Phone linked & verified.");
+            setPhone("");
+            setOtp("");
+            confirmRef.current = null;
+            await fetchMe();
+        } catch (e: any) {
+            setErr(e?.code || e?.message || "Failed to confirm OTP");
+        }
+    }
+
+    async function onLogout() {
+        await signOut(auth).catch(() => {});
+        dispatch(logout());
+        window.location.href = "/login";
+    }
+
+    return (
+        <Layout>
+            <div className="max-w-2xl mx-auto">
+                <div className="mb-6">
+                    <h1 className="text-3xl font-bold">My Account</h1>
+                    <p className="text-sm text-gray-500">Manage your contact &amp; verification details.</p>
+                </div>
+
+                {/* Card: Profile */}
+                <div className="bg-white border rounded-2xl shadow-sm p-6 mb-6">
+                    <div className="flex items-start justify-between">
+                        <div>
+                            <h2 className="text-lg font-semibold">Profile</h2>
+                            <p className="text-xs text-gray-500">
+                                Provider: <span className="font-mono">{providerLabel}</span>
+                            </p>
+                        </div>
+                        <button onClick={onLogout} className="text-sm px-3 py-1.5 rounded-lg border hover:bg-gray-50">
+                            Logout
+                        </button>
+                    </div>
+
+                    {loading ? (
+                        <p className="mt-4 text-gray-500">Loading…</p>
+                    ) : me ? (
+                        <div className="mt-4 space-y-4">
+                            <div>
+                                <div className="text-sm text-gray-500">Email</div>
+                                <div className="flex items-center gap-2">
+                                    <div className="font-medium">{me.email || "-"}</div>
+                                    <Chip ok={me.is_email_verified} label={me.is_email_verified ? "Verified" : "Not verified"} />
+                                </div>
+                            </div>
+                            <div>
+                                <div className="text-sm text-gray-500">Phone</div>
+                                <div className="flex items-center gap-2">
+                                    <div className="font-medium">{me.phone || "-"}</div>
+                                    <Chip ok={me.is_phone_verified} label={me.is_phone_verified ? "Verified" : "Not verified"} />
+                                </div>
+                            </div>
+                        </div>
+                    ) : (
+                        <p className="mt-4 text-red-600">Failed to load profile.</p>
+                    )}
+                </div>
+
+                {/* Card: Actions */}
+                <div className="bg-white border rounded-2xl shadow-sm p-6 mb-6">
+                    <h3 className="text-lg font-semibold mb-4">Verify &amp; Update</h3>
+
+                    {/* Resend Email Verify */}
+                    <div className="mb-4">
+                        <div className="text-sm font-medium mb-1">Email verification</div>
+                        <button onClick={resendVerifyEmail} className="px-4 py-2 rounded-xl border hover:bg-gray-50">
+                            Resend verification email
+                        </button>
+                    </div>
+
+                    {/* Change Email */}
+                    <div className="mb-4">
+                        <div className="text-sm font-medium mb-1">Change email</div>
+                        <div className="flex gap-2">
+                            <input
+                                type="email"
+                                placeholder="new-email@example.com"
+                                value={newEmail}
+                                onChange={(e) => setNewEmail(e.target.value)}
+                                className="border rounded-xl px-3 py-2 flex-1"
+                            />
+                            <button onClick={onChangeEmail} className="px-4 py-2 rounded-xl border hover:bg-gray-50">
+                                Update
+                            </button>
+                        </div>
+                        <p className="text-xs text-gray-500 mt-1">
+                            May require recent sign-in depending on provider.
+                        </p>
+                    </div>
+
+                    {/* Link Phone */}
+                    <div className="mb-2">
+                        <div className="text-sm font-medium mb-1">Link / verify phone</div>
+                        <div className="flex gap-2 mb-2">
+                            <input
+                                type="tel"
+                                placeholder="+66123456789"
+                                value={phone}
+                                onChange={(e) => setPhone(e.target.value)}
+                                className="border rounded-xl px-3 py-2 flex-1"
+                            />
+                            <button id="btn-send-otp" onClick={onPhoneSendOtp} className="px-4 py-2 rounded-xl border hover:bg-gray-50">
+                                Send OTP
+                            </button>
+                            <input
+                                type="text"
+                                placeholder="123456"
+                                value={otp}
+                                onChange={(e) => setOtp(e.target.value)}
+                                className="border rounded-xl px-3 py-2 w-28"
+                            />
+                            <button onClick={onPhoneConfirmOtp} className="px-4 py-2 rounded-xl border hover:bg-gray-50">
+                                Confirm
+                            </button>
+                        </div>
+                        <p className="text-xs text-gray-500">
+                            Use Firebase test numbers on free plan to avoid billing errors.
+                        </p>
+                    </div>
+                </div>
+
+                {/* Alerts */}
+                {!!msg && (
+                    <div className="rounded-xl p-3 bg-green-50 border border-green-200 text-green-700 mb-3">{msg}</div>
+                )}
+                {!!err && (
+                    <div className="rounded-xl p-3 bg-red-50 border border-red-200 text-red-700">{err}</div>
+                )}
+            </div>
+        </Layout>
+    );
+}

--- a/src/pages/api/user/me.ts
+++ b/src/pages/api/user/me.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { withAuth } from "@utils/authMiddleware";
+import { getUserById } from "@repository/user";
+
+export default withAuth(async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== "GET") {
+        res.setHeader("Allow", "GET");
+        return res.status(405).json({ error: "Method Not Allowed" });
+    }
+
+    const { userId } = (req as any).auth || {};
+    if (!userId) {
+        return res.status(401).json({ error: "invalid_token" });
+    }
+
+    const user = await getUserById(Number(userId));
+    if (!user) {
+        return res.status(404).json({ error: "User not found" });
+    }
+
+    return res.status(200).json({
+        user: {
+            id: user.id,
+            email: user.email,
+            phone: user.phone,
+            provider: user.provider,
+            is_email_verified: user.is_email_verified,
+            is_phone_verified: user.is_phone_verified,
+        },
+    });
+});

--- a/src/pages/api/user/send-verify-email.ts
+++ b/src/pages/api/user/send-verify-email.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { sendVerifyEmail } from "@utils/firebaseRest";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        if (req.method !== "POST") {
+            res.setHeader("Allow", "POST");
+            return res.status(405).json({ error: "Method Not Allowed" });
+        }
+        const { idToken } = req.body || {};
+        if (!idToken) return res.status(400).json({ error: "Missing idToken" });
+        await sendVerifyEmail(idToken);
+        res.status(200).json({ ok: true });
+    } catch (e: any) {
+        res.status(400).json({ error: e?.message || "Failed to send verification email" });
+    }
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,31 +1,25 @@
-// src/pages/login.tsx
 import React, { useRef, useState } from "react";
 import Layout from "@components/Layout";
 import { auth, googleProvider, makeRecaptcha } from "@utils/firebaseClient";
-import {
-    signInWithEmailAndPassword,
-    signInWithPopup,
-    signInWithPhoneNumber,
-} from "firebase/auth";
+import { signInWithEmailAndPassword, signInWithPopup, signInWithPhoneNumber } from "firebase/auth";
 import axios from "@utils/apiClient";
 import { useAppDispatch } from "@store/index";
 import { setTokens } from "@store/authSlice";
 
 type Tab = "login" | "signup";
 
-const LoginSignupPage: React.FC = () => {
+export default function LoginSignupPage() {
     const dispatch = useAppDispatch();
     const [tab, setTab] = useState<Tab>("login");
 
-    // shared UI
     const [message, setMessage] = useState("");
     const [lastError, setLastError] = useState<{ code?: string; message?: string } | null>(null);
 
-    // login (email/pw)
+    // login fields
     const [loginEmail, setLoginEmail] = useState("");
     const [loginPassword, setLoginPassword] = useState("");
 
-    // signup (email/pw)
+    // signup fields
     const [suEmail, setSuEmail] = useState("");
     const [suPassword, setSuPassword] = useState("");
     const [suPassword2, setSuPassword2] = useState("");
@@ -34,95 +28,83 @@ const LoginSignupPage: React.FC = () => {
     // phone (both tabs)
     const [phone, setPhone] = useState("");
     const [otp, setOtp] = useState("");
-    const confirmationResultRef = useRef<any>(null);
+    const confirmRef = useRef<any>(null);
 
     function boot() {
-        setLastError(null);
         setMessage("");
+        setLastError(null);
     }
 
-    // ---------- LOGIN FLOWS ----------
-    async function completeLoginBackend(idToken: string) {
+    // backend helpers
+    async function finishLogin(idToken: string) {
         const r = await axios.post("/api/login", { idToken });
         dispatch(setTokens({ accessToken: r.data.accessToken, refreshToken: r.data.refreshToken }));
-        setMessage("Login success");
+        window.location.href = "/";
+    }
+    async function finishSignupWithIdToken(idToken: string, provider: "google" | "phone") {
+        const r = await axios.post("/api/signup", { provider, idToken });
+        dispatch(setTokens({ accessToken: r.data.accessToken, refreshToken: r.data.refreshToken }));
         window.location.href = "/";
     }
 
+    // LOGIN FLOWS
     const onLoginEmail = async () => {
         try {
             boot();
-            console.log("[login] email/password start");
             const cred = await signInWithEmailAndPassword(auth, loginEmail, loginPassword);
             const idToken = await cred.user.getIdToken();
-            await completeLoginBackend(idToken);
+            await finishLogin(idToken);
         } catch (e: any) {
-            console.error("[login] email/password error", e);
             setLastError({ code: e?.code, message: e?.message });
             setMessage(e?.message || "Login failed");
         }
     };
-
     const onLoginGoogle = async () => {
         try {
             boot();
-            console.log("[login] Google");
             const cred = await signInWithPopup(auth, googleProvider);
             const idToken = await cred.user.getIdToken();
-            await completeLoginBackend(idToken);
+            await finishLogin(idToken);
         } catch (e: any) {
-            console.error("[login] Google error", e);
             setLastError({ code: e?.code, message: e?.message });
             setMessage(e?.message || "Login failed");
         }
     };
-
-    const onLoginPhoneRequestOtp = async () => {
+    const onLoginPhoneSend = async () => {
         try {
             boot();
-            console.log("[login] phone request OTP", { phone });
-            const verifier = makeRecaptcha("btn-login-phone-otp");
-            const confirmation = await signInWithPhoneNumber(auth, phone, verifier);
-            confirmationResultRef.current = confirmation;
+            if (!phone) throw new Error("Phone number required");
+            const v = makeRecaptcha("btn-login-phone-otp");
+            const conf = await signInWithPhoneNumber(auth, phone, v);
+            confirmRef.current = conf;
             setMessage("OTP sent.");
+            setOtp("");
         } catch (e: any) {
-            console.error("[login] phone request OTP error", e);
             setLastError({ code: e?.code, message: e?.message });
-            setMessage(`${e?.code || "error"}: ${e?.message || "OTP request failed"}`);
+            setMessage(e?.message || "OTP send failed");
         }
     };
-
-    const onLoginPhoneConfirmOtp = async () => {
+    const onLoginPhoneConfirm = async () => {
         try {
             boot();
-            console.log("[login] phone confirm OTP");
-            const confirmation = confirmationResultRef.current;
-            if (!confirmation) throw new Error("No OTP session. Request OTP first.");
-            const result = await confirmation.confirm(otp);
-            const idToken = await result.user.getIdToken();
-            await completeLoginBackend(idToken);
+            const conf = confirmRef.current;
+            if (!conf) throw new Error("Send OTP first.");
+            if (!otp) throw new Error("Enter the OTP");
+            const r = await conf.confirm(otp);
+            const idToken = await r.user.getIdToken();
+            await finishLogin(idToken);
         } catch (e: any) {
-            console.error("[login] phone confirm error", e);
             setLastError({ code: e?.code, message: e?.message });
-            setMessage(`${e?.code || "error"}: ${e?.message || "OTP confirm failed"}`);
+            setMessage(e?.message || "OTP confirm failed");
         }
     };
 
-    // ---------- SIGNUP FLOWS ----------
-    async function completeSignupBackendWithIdToken(idToken: string) {
-        const r = await axios.post("/api/signup", { provider: "google", idToken }); // provider ignored; server uses token info
-        dispatch(setTokens({ accessToken: r.data.accessToken, refreshToken: r.data.refreshToken }));
-        setMessage("Signup success");
-        window.location.href = "/";
-    }
-
+    // SIGNUP FLOWS
     const onSignupEmail = async () => {
         try {
             boot();
-            if (!suEmail || !suPassword) throw new Error("Email and password are required");
+            if (!suEmail || !suPassword) throw new Error("Email and password required");
             if (suPassword !== suPassword2) throw new Error("Passwords do not match");
-
-            console.log("[signup] email/password via API");
             const r = await axios.post("/api/signup", {
                 provider: "password",
                 email: suEmail,
@@ -130,219 +112,199 @@ const LoginSignupPage: React.FC = () => {
                 sendVerifyEmail: suSendVerify,
             });
             dispatch(setTokens({ accessToken: r.data.accessToken, refreshToken: r.data.refreshToken }));
-            setMessage("Signup success");
+            try {
+                await signInWithEmailAndPassword(auth, suEmail, suPassword);
+            } catch {
+                // best-effort: user may need to login again to refresh Firebase session
+            }
             window.location.href = "/";
         } catch (e: any) {
-            console.error("[signup] email/password API error", e);
             setLastError({ code: e?.response?.data?.code || e?.code, message: e?.response?.data?.error || e?.message });
             setMessage(e?.response?.data?.error || e?.message || "Signup failed");
         }
     };
-
     const onSignupGoogle = async () => {
         try {
             boot();
-            console.log("[signup] Google");
             const cred = await signInWithPopup(auth, googleProvider);
             const idToken = await cred.user.getIdToken();
-            await completeSignupBackendWithIdToken(idToken);
+            await finishSignupWithIdToken(idToken, "google");
         } catch (e: any) {
-            console.error("[signup] Google error", e);
             setLastError({ code: e?.code, message: e?.message });
             setMessage(e?.message || "Signup failed");
         }
     };
-
-    const onSignupPhoneRequestOtp = async () => {
+    const onSignupPhoneSend = async () => {
         try {
             boot();
-            console.log("[signup] phone request OTP");
-            const verifier = makeRecaptcha("btn-signup-phone-otp");
-            const confirmation = await signInWithPhoneNumber(auth, phone, verifier);
-            confirmationResultRef.current = confirmation;
+            if (!phone) throw new Error("Phone number required");
+            const v = makeRecaptcha("btn-signup-phone-otp");
+            const conf = await signInWithPhoneNumber(auth, phone, v);
+            confirmRef.current = conf;
             setMessage("OTP sent.");
+            setOtp("");
         } catch (e: any) {
-            console.error("[signup] phone request OTP error", e);
             setLastError({ code: e?.code, message: e?.message });
-            setMessage(`${e?.code || "error"}: ${e?.message || "OTP request failed"}`);
+            setMessage(e?.message || "OTP send failed");
         }
     };
-
-    const onSignupPhoneConfirmOtp = async () => {
+    const onSignupPhoneConfirm = async () => {
         try {
             boot();
-            console.log("[signup] phone confirm OTP");
-            const confirmation = confirmationResultRef.current;
-            if (!confirmation) throw new Error("No OTP session. Request OTP first.");
-            const result = await confirmation.confirm(otp);
-            const idToken = await result.user.getIdToken();
-            // call signup API (stamps & issues our tokens)
-            const r = await axios.post("/api/signup", { provider: "phone", idToken });
-            dispatch(setTokens({ accessToken: r.data.accessToken, refreshToken: r.data.refreshToken }));
-            setMessage("Signup success");
-            window.location.href = "/";
+            const conf = confirmRef.current;
+            if (!conf) throw new Error("Send OTP first.");
+            if (!otp) throw new Error("Enter the OTP");
+            const r = await conf.confirm(otp);
+            const idToken = await r.user.getIdToken();
+            await finishSignupWithIdToken(idToken, "phone");
         } catch (e: any) {
-            console.error("[signup] phone confirm error", e);
             setLastError({ code: e?.code, message: e?.message });
-            setMessage(`${e?.code || "error"}: ${e?.message || "OTP confirm failed"}`);
+            setMessage(e?.message || "OTP confirm failed");
         }
     };
 
     return (
         <Layout>
-            <h1 className="text-2xl font-semibold mb-6">Login / Signup</h1>
-
-            {/* Tabs */}
-            <div className="flex gap-2 mb-6">
-                <button
-                    className={`px-4 py-2 border rounded ${tab === "login" ? "bg-gray-100" : ""}`}
-                    onClick={() => setTab("login")}
-                >
-                    Login
-                </button>
-                <button
-                    className={`px-4 py-2 border rounded ${tab === "signup" ? "bg-gray-100" : ""}`}
-                    onClick={() => setTab("signup")}
-                >
-                    Signup
-                </button>
-            </div>
-
-            {tab === "login" ? (
-                <>
-                    {/* LOGIN: Email/Password */}
-                    <div className="mb-6 p-4 border rounded">
-                        <h2 className="font-medium mb-2">Email &amp; Password</h2>
-                        <input
-                            type="email"
-                            placeholder="email@example.com"
-                            value={loginEmail}
-                            onChange={(e) => setLoginEmail(e.target.value)}
-                            className="border px-3 py-2 mb-2 w-full"
-                        />
-                        <input
-                            type="password"
-                            placeholder="••••••••"
-                            value={loginPassword}
-                            onChange={(e) => setLoginPassword(e.target.value)}
-                            className="border px-3 py-2 mb-2 w-full"
-                        />
-                        <button onClick={onLoginEmail} className="px-4 py-2 border rounded">Sign in</button>
+            <div className="min-h-[70vh] flex items-center justify-center">
+                <div className="w-full max-w-3xl">
+                    {/* header brand */}
+                    <div className="text-center mb-6">
+                        <h1 className="text-3xl font-bold">Welcome to FoodieGo</h1>
+                        <p className="text-gray-500 text-sm">Sign in to get your favorites faster.</p>
                     </div>
 
-                    {/* LOGIN: Google */}
-                    <div className="mb-6 p-4 border rounded">
-                        <h2 className="font-medium mb-2">Google</h2>
-                        <button onClick={onLoginGoogle} className="px-4 py-2 border rounded">Continue with Google</button>
+                    {/* tabs */}
+                    <div className="mb-4 flex gap-2 justify-center">
+                        <button
+                            onClick={() => setTab("login")}
+                            className={`px-4 py-2 rounded-xl border ${tab === "login" ? "bg-gray-100" : "hover:bg-gray-50"}`}
+                        >
+                            Login
+                        </button>
+                        <button
+                            onClick={() => setTab("signup")}
+                            className={`px-4 py-2 rounded-xl border ${tab === "signup" ? "bg-gray-100" : "hover:bg-gray-50"}`}
+                        >
+                            Signup
+                        </button>
                     </div>
 
-                    {/* LOGIN: Phone */}
-                    <div className="mb-6 p-4 border rounded">
-                        <h2 className="font-medium mb-2">Phone (OTP)</h2>
-                        <input
-                            type="tel"
-                            placeholder="+66123456789"
-                            value={phone}
-                            onChange={(e) => setPhone(e.target.value)}
-                            className="border px-3 py-2 mb-2 w-full"
-                        />
-                        <div className="flex gap-2">
-                            <button id="btn-login-phone-otp" onClick={onLoginPhoneRequestOtp} className="px-4 py-2 border rounded">
-                                Send OTP
+                    <div className="grid md:grid-cols-2 gap-4">
+                        {/* card left: email/pw */}
+                        <div className="bg-white border rounded-2xl shadow-sm p-6">
+                            <h2 className="text-lg font-semibold mb-2">Email &amp; Password</h2>
+
+                            {tab === "login" ? (
+                                <>
+                                    <input
+                                        className="border w-full rounded-xl px-3 py-2 mb-2"
+                                        type="email"
+                                        placeholder="email@example.com"
+                                        value={loginEmail}
+                                        onChange={(e) => setLoginEmail(e.target.value)}
+                                    />
+                                    <input
+                                        className="border w-full rounded-xl px-3 py-2 mb-3"
+                                        type="password"
+                                        placeholder="••••••••"
+                                        value={loginPassword}
+                                        onChange={(e) => setLoginPassword(e.target.value)}
+                                    />
+                                    <button onClick={onLoginEmail} className="px-4 py-2 rounded-xl border w-full hover:bg-gray-50">
+                                        Sign in
+                                    </button>
+                                </>
+                            ) : (
+                                <>
+                                    <input
+                                        className="border w-full rounded-xl px-3 py-2 mb-2"
+                                        type="email"
+                                        placeholder="email@example.com"
+                                        value={suEmail}
+                                        onChange={(e) => setSuEmail(e.target.value)}
+                                    />
+                                    <input
+                                        className="border w-full rounded-xl px-3 py-2 mb-2"
+                                        type="password"
+                                        placeholder="Create password"
+                                        value={suPassword}
+                                        onChange={(e) => setSuPassword(e.target.value)}
+                                    />
+                                    <input
+                                        className="border w-full rounded-xl px-3 py-2 mb-2"
+                                        type="password"
+                                        placeholder="Confirm password"
+                                        value={suPassword2}
+                                        onChange={(e) => setSuPassword2(e.target.value)}
+                                    />
+                                    <label className="text-sm flex items-center gap-2 mb-3">
+                                        <input type="checkbox" checked={suSendVerify} onChange={(e) => setSuSendVerify(e.target.checked)} />
+                                        Send verification email
+                                    </label>
+                                    <button onClick={onSignupEmail} className="px-4 py-2 rounded-xl border w-full hover:bg-gray-50">
+                                        Create account
+                                    </button>
+                                </>
+                            )}
+                        </div>
+
+                        {/* card right: providers */}
+                        <div className="bg-white border rounded-2xl shadow-sm p-6">
+                            <h2 className="text-lg font-semibold mb-2">Quick sign {tab === "login" ? "in" : "up"}</h2>
+                            {/* Google */}
+                            <button
+                                onClick={tab === "login" ? onLoginGoogle : onSignupGoogle}
+                                className="px-4 py-2 rounded-xl border w-full hover:bg-gray-50 mb-4"
+                            >
+                                Continue with Google
                             </button>
-                            <input
-                                type="text"
-                                placeholder="123456"
-                                value={otp}
-                                onChange={(e) => setOtp(e.target.value)}
-                                className="border px-3 py-2"
-                            />
-                            <button onClick={onLoginPhoneConfirmOtp} className="px-4 py-2 border rounded">
-                                Confirm OTP
-                            </button>
+
+                            {/* Phone */}
+                            <div className="space-y-2">
+                                <input
+                                    className="border w-full rounded-xl px-3 py-2"
+                                    type="tel"
+                                    placeholder="+66123456789"
+                                    value={phone}
+                                    onChange={(e) => setPhone(e.target.value)}
+                                />
+                                <div className="flex gap-2">
+                                    <button
+                                        id={tab === "login" ? "btn-login-phone-otp" : "btn-signup-phone-otp"}
+                                        onClick={tab === "login" ? onLoginPhoneSend : onSignupPhoneSend}
+                                        className="px-3 py-2 rounded-xl border hover:bg-gray-50"
+                                    >
+                                        Send OTP
+                                    </button>
+                                    <input
+                                        className="border rounded-xl px-3 py-2 flex-1"
+                                        placeholder="123456"
+                                        value={otp}
+                                        onChange={(e) => setOtp(e.target.value)}
+                                    />
+                                    <button
+                                        onClick={tab === "login" ? onLoginPhoneConfirm : onSignupPhoneConfirm}
+                                        className="px-3 py-2 rounded-xl border hover:bg-gray-50"
+                                    >
+                                        Confirm
+                                    </button>
+                                </div>
+                            </div>
+
+                            <p className="text-xs text-gray-500 mt-3">Use Firebase test numbers on free plan.</p>
                         </div>
                     </div>
-                </>
-            ) : (
-                <>
-                    {/* SIGNUP: Email/Password (server API) */}
-                    <div className="mb-6 p-4 border rounded">
-                        <h2 className="font-medium mb-2">Email &amp; Password (Signup)</h2>
-                        <input
-                            type="email"
-                            placeholder="email@example.com"
-                            value={suEmail}
-                            onChange={(e) => setSuEmail(e.target.value)}
-                            className="border px-3 py-2 mb-2 w-full"
-                        />
-                        <input
-                            type="password"
-                            placeholder="Create password"
-                            value={suPassword}
-                            onChange={(e) => setSuPassword(e.target.value)}
-                            className="border px-3 py-2 mb-2 w-full"
-                        />
-                        <input
-                            type="password"
-                            placeholder="Confirm password"
-                            value={suPassword2}
-                            onChange={(e) => setSuPassword2(e.target.value)}
-                            className="border px-3 py-2 mb-2 w-full"
-                        />
-                        <label className="flex items-center gap-2 mb-3">
-                            <input
-                                type="checkbox"
-                                checked={suSendVerify}
-                                onChange={e => setSuSendVerify(e.target.checked)}
-                            />
-                            Send verification email
-                        </label>
-                        <button onClick={onSignupEmail} className="px-4 py-2 border rounded">Create account</button>
-                    </div>
 
-                    {/* SIGNUP: Google */}
-                    <div className="mb-6 p-4 border rounded">
-                        <h2 className="font-medium mb-2">Google</h2>
-                        <button onClick={onSignupGoogle} className="px-4 py-2 border rounded">Continue with Google</button>
-                    </div>
-
-                    {/* SIGNUP: Phone */}
-                    <div className="mb-6 p-4 border rounded">
-                        <h2 className="font-medium mb-2">Phone (OTP)</h2>
-                        <input
-                            type="tel"
-                            placeholder="+66123456789"
-                            value={phone}
-                            onChange={(e) => setPhone(e.target.value)}
-                            className="border px-3 py-2 mb-2 w-full"
-                        />
-                        <div className="flex gap-2">
-                            <button id="btn-signup-phone-otp" onClick={onSignupPhoneRequestOtp} className="px-4 py-2 border rounded">
-                                Send OTP
-                            </button>
-                            <input
-                                type="text"
-                                placeholder="123456"
-                                value={otp}
-                                onChange={(e) => setOtp(e.target.value)}
-                                className="border px-3 py-2"
-                            />
-                            <button onClick={onSignupPhoneConfirmOtp} className="px-4 py-2 border rounded">
-                                Confirm OTP
-                            </button>
-                        </div>
-                    </div>
-                </>
-            )}
-
-            {message && <p className="text-sm text-gray-700">{message}</p>}
-            {lastError && (
-                <pre className="text-xs mt-3 p-2 bg-gray-100 border rounded overflow-x-auto">
+                    {!!message && (
+                        <div className="mt-4 rounded-xl p-3 bg-green-50 border border-green-200 text-green-700">{message}</div>
+                    )}
+                    {!!lastError && (
+                        <pre className="mt-3 text-xs p-2 bg-red-50 border border-red-200 text-red-700 rounded-xl overflow-x-auto">
 {JSON.stringify(lastError, null, 2)}
-        </pre>
-            )}
+                        </pre>
+                    )}
+                </div>
+            </div>
         </Layout>
     );
-};
-
-export default LoginSignupPage;
+}

--- a/src/repository/user.tsx
+++ b/src/repository/user.tsx
@@ -40,3 +40,13 @@ export async function upsertUser(params: {
     const { rows } = await db.query(sql, vals);
     return rows[0];
 }
+
+export async function getUserById(userId: number): Promise<UserRecord | null> {
+    const sql = `
+        SELECT id, firebase_uid, email, phone, provider, is_email_verified, is_phone_verified, created_at, updated_at
+        FROM tbl_user
+        WHERE id = $1
+    `;
+    const { rows } = await db.query(sql, [userId]);
+    return rows[0] || null;
+}

--- a/src/utils/apiClient.tsx
+++ b/src/utils/apiClient.tsx
@@ -41,7 +41,7 @@ axios.interceptors.response.use(
                     flush(r.data.accessToken);
                     original.headers.Authorization = `Bearer ${r.data.accessToken}`;
                     return axios(original);
-                } catch (e) {
+                } catch {
                     isRefreshing = false;
                     flush(null);
                     store.dispatch(logout());


### PR DESCRIPTION
## Summary
- restyled the combined login/signup experience with tabbed layout, provider quick actions, and improved OTP validation
- added a protected account page that surfaces profile details and supports resend email, email change, phone linking, and logout with token refresh handling
- exposed profile/verification APIs with a repository helper and refreshed the shared layout/navbar to highlight the new account entry point

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce59f5d628832f819596714bd470e9