### PR TITLE
Implement cart persistence, merging, and basket UI

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,11 +1,19 @@
-import React from "react";
+import React, { useState } from "react";
 import Navbar from "./Navbar";
+import FloatingCartButton from "@components/cart/FloatingCartButton";
+import CartDrawer from "@components/cart/CartDrawer";
 
-const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <div className="min-h-screen bg-slate-50">
-        <Navbar />
-        <main className="px-4 py-8 sm:px-6 lg:px-8">{children}</main>
-    </div>
-);
+const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [cartOpen, setCartOpen] = useState(false);
+
+    return (
+        <div className="min-h-screen bg-slate-50">
+            <Navbar />
+            <main className="px-4 py-8 sm:px-6 lg:px-8">{children}</main>
+            <FloatingCartButton onClick={() => setCartOpen(true)} />
+            <CartDrawer open={cartOpen} onClose={() => setCartOpen(false)} />
+        </div>
+    );
+};
 
 export default Layout;

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -3,23 +3,30 @@ import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { RootState, useAppDispatch } from "@store/index";
 import { useRouter } from "next/router";
-import { loadTokens, saveTokens, clearTokens } from "@utils/tokenStorage";
-import { setTokens } from "@store/authSlice";
+import { clearTokens, clearUser, loadTokens, loadUser, saveTokens, saveUser } from "@utils/tokenStorage";
+import { setTokens, setUser } from "@store/authSlice";
 
 export default function RequireAuth({ children }: { children: React.ReactNode }) {
     const router = useRouter();
     const dispatch = useAppDispatch();
     const accessToken = useSelector((s: RootState) => s.auth.accessToken);
     const refreshToken = useSelector((s: RootState) => s.auth.refreshToken);
+    const user = useSelector((s: RootState) => s.auth.user);
     const [hydrated, setHydrated] = useState(false);
     const redirectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
-        const hasRedux = !!accessToken && !!refreshToken;
-        if (!hasRedux) {
+        const hasTokens = !!accessToken && !!refreshToken;
+        if (!hasTokens) {
             const stored = loadTokens();
             if (stored?.accessToken && stored?.refreshToken) {
                 dispatch(setTokens(stored));
+            }
+        }
+        if (!user) {
+            const storedUser = loadUser();
+            if (storedUser) {
+                dispatch(setUser(storedUser));
             }
         }
         setHydrated(true);
@@ -33,6 +40,15 @@ export default function RequireAuth({ children }: { children: React.ReactNode })
             clearTokens();
         }
     }, [accessToken, refreshToken, hydrated]);
+
+    useEffect(() => {
+        if (!hydrated) return;
+        if (user) {
+            saveUser(user);
+        } else {
+            clearUser();
+        }
+    }, [user, hydrated]);
 
     useEffect(() => {
         if (!hydrated) return;

--- a/src/components/cart/CartDrawer.tsx
+++ b/src/components/cart/CartDrawer.tsx
@@ -1,0 +1,388 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { useRouter } from "next/router";
+import axios, { type ApiResponse } from "@utils/apiClient";
+import { QuantityInput } from "@components/common";
+import { buildCartItemKey } from "@utils/cart";
+import { formatTHB } from "@utils/currency";
+import type { CartBranchGroup, CartItem, UserRecord } from "@/types";
+import type { RootState } from "@store/index";
+import { useAppDispatch } from "@store/index";
+import { setUser } from "@store/authSlice";
+import { saveUser } from "@utils/tokenStorage";
+
+type CartDrawerProps = {
+    open: boolean;
+    onClose: () => void;
+};
+
+const ITEM_MAX = 10;
+const CHECKOUT_DRAFT_KEY = "CHECKOUT_DRAFT";
+
+function cloneCard(card: CartBranchGroup[]): CartBranchGroup[] {
+    return card.map((branch) => ({
+        ...branch,
+        productList: branch.productList.map((item) => ({
+            ...item,
+            productAddOns: item.productAddOns.map((addon) => ({ ...addon })),
+        })),
+    }));
+}
+
+function filterEmpty(card: CartBranchGroup[]): CartBranchGroup[] {
+    return card
+        .map((branch) => ({
+            ...branch,
+            productList: branch.productList.filter((item) => item.qty > 0),
+        }))
+        .filter((branch) => branch.productList.length > 0);
+}
+
+export default function CartDrawer({ open, onClose }: CartDrawerProps) {
+    const dispatch = useAppDispatch();
+    const router = useRouter();
+    const user = useSelector((state: RootState) => state.auth.user);
+    const [optimisticCard, setOptimisticCard] = useState<CartBranchGroup[]>([]);
+    const [selectedMap, setSelectedMap] = useState<Record<string, boolean>>({});
+    const [pending, setPending] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const allKeys = useMemo(
+        () =>
+            optimisticCard.flatMap((branch) =>
+                branch.productList.map((item) => buildCartItemKey(branch.branchId, item))
+            ),
+        [optimisticCard]
+    );
+
+    const selectedCount = useMemo(() => allKeys.filter((key) => selectedMap[key]).length, [allKeys, selectedMap]);
+    const allSelected = allKeys.length > 0 && allKeys.every((key) => selectedMap[key]);
+
+    useEffect(() => {
+        if (!open) {
+            setSelectedMap({});
+            return;
+        }
+        const nextCard = user?.card ?? [];
+        setOptimisticCard(nextCard);
+        setSelectedMap((prev) => {
+            const allowed = new Set(
+                nextCard.flatMap((branch) => branch.productList.map((item) => buildCartItemKey(branch.branchId, item)))
+            );
+            const nextSelected: Record<string, boolean> = {};
+            allowed.forEach((key) => {
+                if (prev[key]) {
+                    nextSelected[key] = true;
+                }
+            });
+            return nextSelected;
+        });
+    }, [open, user?.card]);
+
+    const persistCard = useCallback(
+        async (nextCard: CartBranchGroup[], prevCard: CartBranchGroup[]) => {
+            setPending(true);
+            try {
+                if (!user) {
+                    setOptimisticCard(prevCard);
+                    return;
+                }
+
+                const response = await axios.post<ApiResponse<{ user: UserRecord }>>("/api/card/save", {
+                    card: nextCard,
+                    replace: true,
+                });
+                if (response.data.code !== "OK") {
+                    throw new Error(response.data.message || "Failed to save cart");
+                }
+                const updatedUser = response.data.body?.user;
+                if (!updatedUser) {
+                    throw new Error("Invalid cart response");
+                }
+                dispatch(setUser(updatedUser));
+                saveUser(updatedUser);
+                setError(null);
+            } catch (err: any) {
+                const message = err?.response?.data?.message || err?.message || "Failed to update cart";
+                setError(message);
+                setOptimisticCard(prevCard);
+            } finally {
+                setPending(false);
+            }
+        },
+        [dispatch, user]
+    );
+
+    const handleToggleSelectAll = () => {
+        setError(null);
+        if (allSelected) {
+            setSelectedMap({});
+            return;
+        }
+        const next: Record<string, boolean> = {};
+        allKeys.forEach((key) => {
+            next[key] = true;
+        });
+        setSelectedMap(next);
+    };
+
+    const handleToggleItem = (key: string) => {
+        setError(null);
+        setSelectedMap((prev) => ({ ...prev, [key]: !prev[key] }));
+    };
+
+    const handleQtyChange = (branchId: string, itemKey: string, nextQty: number) => {
+        if (pending) return;
+        setError(null);
+        const prevCard = cloneCard(optimisticCard);
+        const updated = optimisticCard.map((branch) => {
+            if (branch.branchId !== branchId) return branch;
+            return {
+                ...branch,
+                productList: branch.productList.map((item) => {
+                    const key = buildCartItemKey(branch.branchId, item);
+                    if (key !== itemKey) return item;
+                    const clamped = Math.max(1, Math.min(nextQty, ITEM_MAX));
+                    if (clamped === item.qty) return item;
+                    return { ...item, qty: clamped };
+                }),
+            };
+        });
+        setOptimisticCard(updated);
+        void persistCard(filterEmpty(updated), prevCard);
+    };
+
+    const handleRemoveItem = (branchId: string, itemKey: string) => {
+        if (pending) return;
+        setError(null);
+        const prevCard = cloneCard(optimisticCard);
+        const updated = optimisticCard
+            .map((branch) => {
+                if (branch.branchId !== branchId) return branch;
+                const filtered = branch.productList.filter(
+                    (item) => buildCartItemKey(branch.branchId, item) !== itemKey
+                );
+                return { ...branch, productList: filtered };
+            })
+            .filter((branch) => branch.productList.length > 0);
+        setOptimisticCard(updated);
+        setSelectedMap((prev) => {
+            const next = { ...prev };
+            delete next[itemKey];
+            return next;
+        });
+        void persistCard(updated, prevCard);
+    };
+
+    const handleRemoveSelected = () => {
+        if (pending || selectedCount === 0) return;
+        setError(null);
+        const prevCard = cloneCard(optimisticCard);
+        const updated = optimisticCard
+            .map((branch) => {
+                const filtered = branch.productList.filter(
+                    (item) => !selectedMap[buildCartItemKey(branch.branchId, item)]
+                );
+                return { ...branch, productList: filtered };
+            })
+            .filter((branch) => branch.productList.length > 0);
+        setOptimisticCard(updated);
+        setSelectedMap({});
+        void persistCard(updated, prevCard);
+    };
+
+    const handleCheckoutSelected = async () => {
+        if (pending) return;
+        const draft = optimisticCard
+            .map((branch) => ({
+                ...branch,
+                productList: branch.productList.filter((item) =>
+                    selectedMap[buildCartItemKey(branch.branchId, item)]
+                ),
+            }))
+            .filter((branch) => branch.productList.length > 0);
+
+        if (draft.length === 0) {
+            setError("Select at least one item");
+            return;
+        }
+
+        if (typeof window !== "undefined") {
+            window.localStorage.setItem(CHECKOUT_DRAFT_KEY, JSON.stringify(draft));
+        }
+        onClose();
+        await router.push("/checkout");
+    };
+
+    if (!open) return null;
+
+    const renderAddOns = (item: CartItem) => {
+        if (!item.productAddOns.length) return null;
+        const formatted = item.productAddOns
+            .map((addon) => `+ ${addon.name} ${formatTHB(addon.price)}`)
+            .join(", ");
+        return <p className="mt-1 text-xs text-slate-500">{formatted}</p>;
+    };
+
+    const renderBranch = (branch: CartBranchGroup) => (
+        <div key={branch.branchId} className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm">
+            <div className="flex items-start gap-3">
+                {branch.branchImage ? (
+                    <img
+                        src={branch.branchImage}
+                        alt={branch.branchName}
+                        className="h-12 w-12 rounded-xl object-cover"
+                    />
+                ) : (
+                    <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-50 text-xs font-semibold text-emerald-700">
+                        {branch.branchName.slice(0, 2).toUpperCase()}
+                    </div>
+                )}
+                <div>
+                    <h3 className="text-sm font-semibold text-slate-900">{branch.branchName}</h3>
+                    {branch.companyId && (
+                        <p className="text-xs text-slate-500">Branch #{branch.companyId}</p>
+                    )}
+                </div>
+            </div>
+
+            <ul className="mt-4 space-y-3">
+                {branch.productList.map((item) => {
+                    const key = buildCartItemKey(branch.branchId, item);
+                    const base = item.price;
+                    const addonsTotal = item.productAddOns.reduce((sum, addon) => sum + addon.price, 0);
+                    const itemTotal = (base + addonsTotal) * item.qty;
+                    return (
+                        <li
+                            key={key}
+                            className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-3 sm:flex-row sm:items-start sm:justify-between"
+                        >
+                            <div className="flex items-start gap-3">
+                                <input
+                                    type="checkbox"
+                                    checked={!!selectedMap[key]}
+                                    onChange={() => handleToggleItem(key)}
+                                    className="mt-1 h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-200"
+                                />
+                                <div>
+                                    <p className="text-sm font-semibold text-slate-900">{item.productName}</p>
+                                    {renderAddOns(item)}
+                                    <p className="mt-2 text-sm font-semibold text-emerald-600">{formatTHB(itemTotal)}</p>
+                                </div>
+                            </div>
+                            <div className="flex items-center justify-between gap-3 sm:flex-col sm:items-end">
+                                <QuantityInput
+                                    value={item.qty}
+                                    min={1}
+                                    max={ITEM_MAX}
+                                    onChange={(next) => handleQtyChange(branch.branchId, key, next)}
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => handleRemoveItem(branch.branchId, key)}
+                                    className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+                                >
+                                    <svg
+                                        aria-hidden="true"
+                                        className="h-4 w-4"
+                                        viewBox="0 0 24 24"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        strokeWidth="1.6"
+                                    >
+                                        <path d="M5 7h14" strokeLinecap="round" />
+                                        <path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" strokeLinecap="round" />
+                                        <path d="M10 11v6M14 11v6" strokeLinecap="round" />
+                                        <path d="M6 7l1 12a1 1 0 0 0 1 .92h8a1 1 0 0 0 1-.92L18 7" strokeLinecap="round" />
+                                    </svg>
+                                    Remove
+                                </button>
+                            </div>
+                        </li>
+                    );
+                })}
+            </ul>
+        </div>
+    );
+
+    const hasItems = optimisticCard.some((branch) => branch.productList.length > 0);
+
+    return (
+        <div className="fixed inset-0 z-50">
+            <div
+                className="absolute inset-0 bg-slate-900/40"
+                role="presentation"
+                onClick={onClose}
+            />
+            <div className="absolute inset-0 flex h-full flex-col justify-end sm:justify-start sm:items-end">
+                <aside className="flex h-[88vh] w-full flex-col rounded-t-3xl bg-white shadow-xl sm:h-full sm:max-w-md sm:rounded-none sm:border-l sm:border-slate-200">
+                    <header className="flex items-center justify-between border-b border-slate-200 px-5 py-4">
+                        <div>
+                            <h2 className="text-base font-semibold text-slate-900">My Basket</h2>
+                            <p className="text-xs text-slate-500">Review your selections before checkout.</p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+                            aria-label="Close cart"
+                        >
+                            <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
+                                <path d="m4 4 8 8M12 4 4 12" strokeLinecap="round" />
+                            </svg>
+                        </button>
+                    </header>
+
+                    <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+                        {!hasItems ? (
+                            <div className="flex h-full flex-col items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center">
+                                <p className="text-sm font-medium text-slate-700">Your basket is empty.</p>
+                                <p className="mt-1 text-xs text-slate-500">Add some dishes to get started.</p>
+                            </div>
+                        ) : (
+                            optimisticCard.map((branch) => renderBranch(branch))
+                        )}
+                    </div>
+
+                    <footer className="border-t border-slate-200 bg-white px-5 py-4">
+                        {error && (
+                            <div className="mb-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+                                {error}
+                            </div>
+                        )}
+                        <div className="mb-3 flex items-center justify-between text-xs text-slate-600">
+                            <label className="inline-flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-200"
+                                    checked={allSelected && allKeys.length > 0}
+                                    onChange={handleToggleSelectAll}
+                                />
+                                Select all ({selectedCount}/{allKeys.length})
+                            </label>
+                            {pending && <span className="text-emerald-600">Updating…</span>}
+                        </div>
+                        <div className="flex flex-col gap-3 sm:flex-row">
+                            <button
+                                type="button"
+                                onClick={handleRemoveSelected}
+                                disabled={selectedCount === 0 || pending}
+                                className="inline-flex flex-1 items-center justify-center rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                                Remove Selected
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleCheckoutSelected}
+                                disabled={selectedCount === 0 || pending || !hasItems}
+                                className="inline-flex flex-1 items-center justify-center rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500 focus:outline-none focus:ring-4 focus:ring-emerald-100 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                                Checkout Selected
+                            </button>
+                        </div>
+                    </footer>
+                </aside>
+            </div>
+        </div>
+    );
+}

--- a/src/components/cart/FloatingCartButton.tsx
+++ b/src/components/cart/FloatingCartButton.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+import type { RootState } from "@store/index";
+import { totalItemCount } from "@utils/cart";
+
+type FloatingCartButtonProps = {
+    onClick: () => void;
+};
+
+export default function FloatingCartButton({ onClick }: FloatingCartButtonProps) {
+    const card = useSelector((state: RootState) => state.auth.user?.card ?? []);
+    const hasUser = useSelector((state: RootState) => !!state.auth.user);
+
+    const count = useMemo(() => totalItemCount(card), [card]);
+
+    if (!hasUser) return null;
+
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="fixed bottom-6 right-6 z-40 inline-flex items-center gap-2 rounded-full bg-emerald-600 px-5 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-emerald-500 focus:outline-none focus:ring-4 focus:ring-emerald-100 active:scale-[0.98]"
+            aria-label="Open cart"
+        >
+            <span className="relative inline-flex items-center justify-center">
+                <svg
+                    aria-hidden="true"
+                    className="h-5 w-5"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                >
+                    <path
+                        d="M3.5 5h1.89c.45 0 .84.3.95.73l.44 1.77M7 12h10.74a1 1 0 0 0 .98-.8l1-4.8A1 1 0 0 0 18.76 5H6.78"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    />
+                    <path
+                        d="M9 20a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM18 20a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    />
+                </svg>
+                <span className="absolute -top-2 -right-3 inline-flex min-w-[1.5rem] items-center justify-center rounded-full bg-white px-2 py-0.5 text-xs font-semibold text-emerald-600 shadow-sm">
+                    {count}
+                </span>
+            </span>
+            <span className="hidden sm:inline">Basket</span>
+        </button>
+    );
+}

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -3,9 +3,9 @@ import Layout from "@components/Layout";
 import axios, { type ApiResponse } from "@utils/apiClient";
 import { auth, makeRecaptcha } from "@utils/firebaseClient";
 import { useAppDispatch } from "@store/index";
-import { logout } from "@store/authSlice";
-import {linkWithPhoneNumber, signInWithPhoneNumber, signOut} from "firebase/auth";
-import { clearTokens } from "@utils/tokenStorage";
+import { logout, setUser } from "@store/authSlice";
+import { linkWithPhoneNumber, signInWithPhoneNumber, signOut } from "firebase/auth";
+import { clearTokens, clearUser, saveUser } from "@utils/tokenStorage";
 import { useRouter } from "next/router";
 
 type Me = {
@@ -88,6 +88,8 @@ export default function AccountPage() {
                 throw new Error("Invalid profile response");
             }
             setMe(normalizeUser(user));
+            dispatch(setUser(user));
+            saveUser(user);
             setError("");
         } catch (e: any) {
             setError(e?.response?.data?.message || e?.message || "Failed to load profile");
@@ -111,6 +113,8 @@ export default function AccountPage() {
             throw new Error("Invalid account response");
         }
         setMe(normalizeUser(user));
+        dispatch(setUser(user));
+        saveUser(user);
     }
 
     async function handleVerifyEmail() {
@@ -216,6 +220,7 @@ export default function AccountPage() {
         await signOut(auth).catch(() => {});
         dispatch(logout());
         clearTokens();
+        clearUser();
         router.replace("/login");
     }
 

--- a/src/pages/api/card/save.ts
+++ b/src/pages/api/card/save.ts
@@ -1,32 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import type { CartAddOn, CartBranchGroup, CartItem, UserRecord } from "@/types";
 import { resolveAuth } from "@utils/authMiddleware";
-import { getConfigValue } from "@repository/config";
-import { getUserCard, saveUserCard } from "@repository/user";
+import { getConfigValue, getNumberConfig } from "@repository/config";
+import { getUserByFirebaseUid, saveUserCard } from "@repository/user";
 import { logError } from "@utils/logger";
 
 export const config = { runtime: "nodejs" };
 
 type JsonResponse<T = any> = { code: string; message: string; body: T };
 
-type CardAddOn = { name: string; price: number };
+type SaveCardRequest = { add?: unknown; card?: unknown; replace?: boolean };
 
-type CardProduct = {
-    productId: string;
-    productName: string;
-    productAddOns: CardAddOn[];
-    qty: number;
-    price: number;
-};
-
-type CardBranch = {
-    branchId: string;
-    companyId: string;
-    branchName: string;
-    branchImage: string | null;
-    productList: CardProduct[];
-};
-
-type SaveCardRequest = { card: unknown };
+const DEFAULT_MAX_QTY_PER_ITEM = 10;
 
 function toId(value: unknown, field: string): string {
     if (typeof value === "string" && value.trim()) {
@@ -72,10 +57,11 @@ function toQuantity(value: unknown): number {
     return rounded;
 }
 
-function sanitizeAddOns(input: unknown): CardAddOn[] {
+function sanitizeAddOns(input: unknown): CartAddOn[] {
     if (!Array.isArray(input)) {
         return [];
     }
+
     return input.map((raw, index) => {
         if (!raw || typeof raw !== "object") {
             throw new Error(`Invalid add-on at index ${index}`);
@@ -86,7 +72,16 @@ function sanitizeAddOns(input: unknown): CardAddOn[] {
     });
 }
 
-function sanitizeProduct(raw: unknown, index: number): CardProduct {
+function sortAddOns(addOns: CartAddOn[]): CartAddOn[] {
+    return [...addOns].sort((a, b) => {
+        if (a.name === b.name) {
+            return a.price - b.price;
+        }
+        return a.name.localeCompare(b.name);
+    });
+}
+
+function sanitizeProduct(raw: unknown, index: number): CartItem {
     if (!raw || typeof raw !== "object") {
         throw new Error(`Invalid product at index ${index}`);
     }
@@ -94,11 +89,11 @@ function sanitizeProduct(raw: unknown, index: number): CardProduct {
     const productName = toName((raw as any).productName, "productName");
     const price = toNumber((raw as any).price, "price");
     const qty = toQuantity((raw as any).qty);
-    const productAddOns = sanitizeAddOns((raw as any).productAddOns);
-    return { productId, productName, productAddOns, price, qty };
+    const productAddOns = sortAddOns(sanitizeAddOns((raw as any).productAddOns));
+    return { productId, productName, price, qty, productAddOns };
 }
 
-function sanitizeBranch(raw: unknown, index: number): CardBranch {
+function sanitizeBranch(raw: unknown, index: number): CartBranchGroup {
     if (!raw || typeof raw !== "object") {
         throw new Error(`Invalid branch at index ${index}`);
     }
@@ -110,75 +105,155 @@ function sanitizeBranch(raw: unknown, index: number): CardBranch {
     if (!Array.isArray(productListRaw) || productListRaw.length === 0) {
         throw new Error("productList must contain at least one product");
     }
-    const productList = productListRaw.map((item: unknown, productIndex: number) =>
-        sanitizeProduct(item, productIndex)
-    );
+    const productList = productListRaw.map((item: unknown, productIndex: number) => sanitizeProduct(item, productIndex));
     return { branchId, companyId, branchName, branchImage, productList };
 }
 
-function sanitizeCard(input: unknown): CardBranch[] {
+function sanitizeCardStrict(input: unknown): CartBranchGroup[] {
     if (!Array.isArray(input)) {
         throw new Error("card must be an array");
     }
     return input.map((raw, index) => sanitizeBranch(raw, index));
 }
 
-function cloneBranch(branch: CardBranch): CardBranch {
+function sanitizeExistingCard(input: unknown): CartBranchGroup[] {
+    try {
+        return sanitizeCardStrict(input);
+    } catch {
+        return [];
+    }
+}
+
+function sanitizeAddRequest(raw: unknown): CartBranchGroup[] {
+    if (!raw || typeof raw !== "object") {
+        throw new Error("Invalid add payload");
+    }
+
+    const branchId = toId((raw as any).branchId, "branchId");
+    const companyId = toId((raw as any).companyId, "companyId");
+    const branchName = toName((raw as any).branchName, "branchName");
+    const branchImage = toNullableString((raw as any).branchImage);
+
+    const productSources: unknown[] = [];
+    if ((raw as any).item) {
+        productSources.push((raw as any).item);
+    }
+    if (Array.isArray((raw as any).items)) {
+        productSources.push(...((raw as any).items as unknown[]));
+    }
+    if (Array.isArray((raw as any).productList)) {
+        productSources.push(...((raw as any).productList as unknown[]));
+    }
+
+    if (productSources.length === 0) {
+        throw new Error("add.item required");
+    }
+
+    const productList = productSources.map((item, index) => sanitizeProduct(item, index));
+    return [
+        {
+            branchId,
+            companyId,
+            branchName,
+            branchImage,
+            productList,
+        },
+    ];
+}
+
+function clampQty(qty: number, maxQty: number): number {
+    return Math.min(Math.max(qty, 1), maxQty);
+}
+
+function cloneItem(item: CartItem, maxQty: number): CartItem {
+    return {
+        productId: item.productId,
+        productName: item.productName,
+        price: item.price,
+        qty: clampQty(item.qty, maxQty),
+        productAddOns: item.productAddOns.map((addon) => ({ ...addon })),
+    };
+}
+
+function cloneBranch(branch: CartBranchGroup, maxQty: number): CartBranchGroup {
     return {
         branchId: branch.branchId,
         companyId: branch.companyId,
         branchName: branch.branchName,
         branchImage: branch.branchImage,
-        productList: branch.productList.map((product) => ({
-            productId: product.productId,
-            productName: product.productName,
-            price: product.price,
-            qty: product.qty,
-            productAddOns: product.productAddOns.map((addon) => ({ ...addon })),
-        })),
+        productList: branch.productList.map((item) => cloneItem(item, maxQty)),
     };
 }
 
-function mergeCards(base: CardBranch[], patch: CardBranch[]): CardBranch[] {
-    const resultMap = new Map<string, CardBranch>();
+function canonicalizeAddOns(addOns: CartAddOn[]): string {
+    const sorted = sortAddOns(addOns);
+    return JSON.stringify(sorted);
+}
+
+function variantKey(branchId: string, item: CartItem): string {
+    return `${branchId}|${item.productId}|${canonicalizeAddOns(item.productAddOns)}`;
+}
+
+function mergeCards(base: CartBranchGroup[], patch: CartBranchGroup[], maxQty: number): CartBranchGroup[] {
+    const branchMap = new Map<string, CartBranchGroup>();
 
     for (const branch of base) {
-        resultMap.set(`${branch.companyId}:${branch.branchId}`, cloneBranch(branch));
+        branchMap.set(branch.branchId, cloneBranch(branch, maxQty));
     }
 
     for (const branch of patch) {
-        const key = `${branch.companyId}:${branch.branchId}`;
-        const existing = resultMap.get(key);
+        const existing = branchMap.get(branch.branchId);
         if (!existing) {
-            resultMap.set(key, cloneBranch(branch));
+            branchMap.set(branch.branchId, cloneBranch(branch, maxQty));
             continue;
         }
+
         existing.branchName = branch.branchName;
         existing.branchImage = branch.branchImage;
+
         for (const product of branch.productList) {
-            existing.productList.push({
-                productId: product.productId,
-                productName: product.productName,
-                price: product.price,
-                qty: product.qty,
-                productAddOns: product.productAddOns.map((addon) => ({ ...addon })),
-            });
+            const normalized = cloneItem(product, maxQty);
+            const key = variantKey(branch.branchId, normalized);
+            const match = existing.productList.find(
+                (item) => item.productId === normalized.productId && variantKey(branch.branchId, item) === key
+            );
+
+            if (match) {
+                match.qty = Math.min(match.qty + normalized.qty, maxQty);
+                match.price = normalized.price;
+                match.productName = normalized.productName;
+                match.productAddOns = normalized.productAddOns.map((addon) => ({ ...addon }));
+            } else {
+                existing.productList.push({
+                    productId: normalized.productId,
+                    productName: normalized.productName,
+                    price: normalized.price,
+                    qty: normalized.qty,
+                    productAddOns: normalized.productAddOns.map((addon) => ({ ...addon })),
+                });
+            }
         }
     }
 
-    return Array.from(resultMap.values());
+    return Array.from(branchMap.values());
 }
 
-function totalQuantity(card: CardBranch[]): number {
-    return card.reduce((acc, branch) => {
-        const branchQty = branch.productList.reduce((sum, product) => sum + product.qty, 0);
-        return acc + branchQty;
-    }, 0);
+function filterEmptyBranches(card: CartBranchGroup[]): CartBranchGroup[] {
+    return card
+        .map((branch) => ({
+            ...branch,
+            productList: branch.productList.filter((item) => item.qty > 0),
+        }))
+        .filter((branch) => branch.productList.length > 0);
+}
+
+function totalUniqueItems(card: CartBranchGroup[]): number {
+    return card.reduce((acc, branch) => acc + branch.productList.length, 0);
 }
 
 export default async function handler(
     req: NextApiRequest,
-    res: NextApiResponse<JsonResponse<{ card: CardBranch[] } | null>>
+    res: NextApiResponse<JsonResponse<{ user: UserRecord } | null>>
 ) {
     if (req.method !== "POST") {
         res.setHeader("Allow", "POST");
@@ -196,32 +271,60 @@ export default async function handler(
         }
 
         const body = req.body as SaveCardRequest;
-        const incomingCard = sanitizeCard(body?.card);
+        const replace = body?.replace === true;
 
-        const existingRaw = await getUserCard(auth.uid);
-        const existingCard = existingRaw.length ? sanitizeCard(existingRaw) : [];
+        const currentUser = await getUserByFirebaseUid(auth.uid);
+        const existingCard = sanitizeExistingCard(currentUser?.card ?? []);
+        const maxQtyPerItem = await getNumberConfig("MAX_QTY_PER_ITEM", DEFAULT_MAX_QTY_PER_ITEM);
 
-        const merged = mergeCards(existingCard, incomingCard);
+        let nextCard: CartBranchGroup[] = existingCard;
 
-        const configValue = await getConfigValue("MAXIMUM_CARD");
-        const parsedLimit = Number(configValue);
-        const limit = Number.isFinite(parsedLimit) ? parsedLimit : 100;
-        const totalQty = totalQuantity(merged);
+        if (replace) {
+            const sanitized = sanitizeCardStrict(body?.card ?? []);
+            nextCard = mergeCards([], sanitized, maxQtyPerItem);
+        } else {
+            let additions: CartBranchGroup[] = [];
+            if (body?.add) {
+                additions = sanitizeAddRequest(body.add);
+            } else if (body?.card) {
+                const sanitizedLegacy = sanitizeCardStrict(body.card);
+                additions = sanitizedLegacy.length > 0 ? [sanitizedLegacy[0]] : [];
+            }
 
-        if (totalQty > limit) {
-            return res
-                .status(400)
-                .json({ code: "CARD_LIMIT_EXCEEDED", message: "Card item limit exceeded", body: null });
+            if (additions.length === 0) {
+                if (currentUser) {
+                    return res.status(200).json({ code: "OK", message: "No changes", body: { user: currentUser } });
+                }
+                const persisted = await saveUserCard(auth.uid, existingCard);
+                return res.status(200).json({ code: "OK", message: "No changes", body: { user: persisted } });
+            }
+
+            nextCard = mergeCards(existingCard, additions, maxQtyPerItem);
         }
 
-        const savedRaw = await saveUserCard(auth.uid, merged);
-        const savedCard = savedRaw.length ? sanitizeCard(savedRaw) : [];
+        nextCard = filterEmptyBranches(nextCard);
 
-        return res.status(200).json({ code: "OK", message: "success", body: { card: savedCard } });
+        const rawLimit = await getConfigValue("MAXIMUM_CARD");
+        const parsedLimit = Number(rawLimit);
+        const maximumItems = Number.isFinite(parsedLimit) ? parsedLimit : 100;
+        const uniqueItems = totalUniqueItems(nextCard);
+
+        if (uniqueItems > maximumItems) {
+            return res
+                .status(400)
+                .json({ code: "CARD_LIMIT_EXCEEDED", message: "Cart item limit exceeded", body: null });
+        }
+
+        const savedUser = await saveUserCard(auth.uid, nextCard);
+        return res.status(200).json({ code: "OK", message: "Saved", body: { user: savedUser } });
     } catch (error: any) {
-        if (error instanceof Error &&
-            (error.message.includes("Invalid") || error.message.includes("Quantity"))) {
-            return res.status(400).json({ code: "BAD_REQUEST", message: error.message, body: null });
+        if (error instanceof Error) {
+            if (error.message === "Quantity must be at least 1") {
+                return res.status(400).json({ code: "INVALID_QTY", message: error.message, body: null });
+            }
+            if (error.message.startsWith("Invalid") || error.message.includes("must")) {
+                return res.status(400).json({ code: "BAD_REQUEST", message: error.message, body: null });
+            }
         }
         logError("card save error", { message: error?.message });
         return res

--- a/src/pages/api/login.ts
+++ b/src/pages/api/login.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { verifyFirebaseIdToken } from "@utils/firebaseVerify";
-import { upsertUser } from "@repository/user";
+import { getUserByFirebaseUid, upsertUser } from "@repository/user";
 import { signAccessToken, mintRefreshToken } from "@utils/jwt";
 import { logInfo, logError } from "@utils/logger";
 
@@ -70,6 +70,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
             isPhoneVerified,
         });
 
+        const freshUser = await getUserByFirebaseUid(firebaseUid);
+
         const accessToken = signAccessToken({ uid: firebaseUid, userId: user.id });
         const refreshToken = mintRefreshToken({ uid: firebaseUid, userId: user.id });
 
@@ -83,11 +85,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                 refreshToken,
                 user: {
                     id: user.id,
-                    email: user.email,
-                    phone: user.phone,
-                    provider: user.provider,
-                    is_email_verified: user.is_email_verified,
-                    is_phone_verified: user.is_phone_verified,
+                    firebase_uid: freshUser?.firebase_uid ?? user.firebase_uid,
+                    email: freshUser?.email ?? user.email,
+                    phone: freshUser?.phone ?? user.phone,
+                    provider: freshUser?.provider ?? user.provider,
+                    is_email_verified: freshUser?.is_email_verified ?? user.is_email_verified ?? null,
+                    is_phone_verified: freshUser?.is_phone_verified ?? user.is_phone_verified ?? null,
+                    card: freshUser?.card ?? [],
+                    created_at: freshUser?.created_at ?? user.created_at,
+                    updated_at: freshUser?.updated_at ?? user.updated_at,
                 },
             },
         });

--- a/src/pages/api/signup.ts
+++ b/src/pages/api/signup.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { signUpEmailPassword, sendVerifyEmail } from "@utils/firebaseRest";
 import { verifyFirebaseIdToken } from "@utils/firebaseVerify";
-import { upsertUser } from "@repository/user";
+import { getUserByFirebaseUid, upsertUser } from "@repository/user";
 import { signAccessToken, mintRefreshToken } from "@utils/jwt";
 import { logInfo, logError } from "@utils/logger";
 
@@ -92,6 +92,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
             isPhoneVerified,
         });
 
+        const freshUser = await getUserByFirebaseUid(firebaseUid);
+
         const accessToken = signAccessToken({ uid: firebaseUid, userId: user.id });
         const refreshToken = mintRefreshToken({ uid: firebaseUid, userId: user.id });
 
@@ -105,11 +107,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                 refreshToken,
                 user: {
                     id: user.id,
-                    email: user.email,
-                    phone: user.phone,
-                    provider: user.provider,
-                    is_email_verified: user.is_email_verified,
-                    is_phone_verified: user.is_phone_verified,
+                    firebase_uid: freshUser?.firebase_uid ?? user.firebase_uid,
+                    email: freshUser?.email ?? user.email,
+                    phone: freshUser?.phone ?? user.phone,
+                    provider: freshUser?.provider ?? user.provider,
+                    is_email_verified: freshUser?.is_email_verified ?? user.is_email_verified ?? null,
+                    is_phone_verified: freshUser?.is_phone_verified ?? user.is_phone_verified ?? null,
+                    card: freshUser?.card ?? [],
+                    created_at: freshUser?.created_at ?? user.created_at,
+                    updated_at: freshUser?.updated_at ?? user.updated_at,
                 },
             },
         });

--- a/src/pages/api/user/me.ts
+++ b/src/pages/api/user/me.ts
@@ -31,11 +31,15 @@ export default withAuth(async function handler(req: NextApiRequest, res: NextApi
             body: {
                 user: {
                     id: user.id,
+                    firebase_uid: user.firebase_uid,
                     email: user.email,
                     phone: user.phone,
                     provider: user.provider,
                     is_email_verified: user.is_email_verified,
                     is_phone_verified: user.is_phone_verified,
+                    card: user.card,
+                    created_at: user.created_at,
+                    updated_at: user.updated_at,
                 },
             },
         });

--- a/src/pages/checkout.tsx
+++ b/src/pages/checkout.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from "react";
+import Layout from "@components/Layout";
+import type { CartBranchGroup } from "@/types";
+import { formatTHB } from "@utils/currency";
+import Link from "next/link";
+
+const CHECKOUT_DRAFT_KEY = "CHECKOUT_DRAFT";
+
+export default function CheckoutPage() {
+    const [draft, setDraft] = useState<CartBranchGroup[]>([]);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const raw = window.localStorage.getItem(CHECKOUT_DRAFT_KEY);
+        if (!raw) {
+            setDraft([]);
+            return;
+        }
+        try {
+            const parsed = JSON.parse(raw) as CartBranchGroup[];
+            setDraft(Array.isArray(parsed) ? parsed : []);
+        } catch {
+            setDraft([]);
+        }
+    }, []);
+
+    const total = useMemo(() => {
+        return draft.reduce((branchAcc, branch) => {
+            const branchTotal = branch.productList.reduce((itemAcc, item) => {
+                const addOns = item.productAddOns.reduce((sum, addon) => sum + addon.price, 0);
+                return itemAcc + (item.price + addOns) * item.qty;
+            }, 0);
+            return branchAcc + branchTotal;
+        }, 0);
+    }, [draft]);
+
+    return (
+        <Layout>
+            <div className="mx-auto max-w-3xl space-y-6">
+                <header className="flex flex-col gap-2">
+                    <h1 className="text-2xl font-semibold text-slate-900">Checkout</h1>
+                    <p className="text-sm text-slate-500">Review your selected dishes before placing the order.</p>
+                </header>
+
+                {draft.length === 0 ? (
+                    <div className="rounded-2xl border border-slate-200 bg-white p-6 text-center shadow-sm">
+                        <p className="text-sm font-medium text-slate-700">No items selected for checkout.</p>
+                        <p className="mt-2 text-xs text-slate-500">
+                            Return to the menu and add items to your basket first.
+                        </p>
+                        <Link
+                            href="/"
+                            className="mt-4 inline-flex items-center justify-center rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500 focus:outline-none focus:ring-4 focus:ring-emerald-100"
+                        >
+                            Back to home
+                        </Link>
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        {draft.map((branch) => (
+                            <div key={branch.branchId} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                                <h2 className="text-sm font-semibold text-slate-900">{branch.branchName}</h2>
+                                <ul className="mt-3 space-y-3">
+                                    {branch.productList.map((item) => {
+                                        const addOns = item.productAddOns.reduce(
+                                            (sum, addon) => sum + addon.price,
+                                            0
+                                        );
+                                        const totalPrice = (item.price + addOns) * item.qty;
+                                        return (
+                                            <li key={`${item.productId}-${item.qty}-${totalPrice}`} className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                                                <div className="flex items-center justify-between">
+                                                    <div>
+                                                        <p className="text-sm font-medium text-slate-800">{item.productName}</p>
+                                                        {item.productAddOns.length > 0 && (
+                                                            <p className="text-xs text-slate-500">
+                                                                {item.productAddOns
+                                                                    .map((addon) => `+ ${addon.name} ${formatTHB(addon.price)}`)
+                                                                    .join(", ")}
+                                                            </p>
+                                                        )}
+                                                        <p className="mt-1 text-xs text-slate-500">Qty: {item.qty}</p>
+                                                    </div>
+                                                    <span className="text-sm font-semibold text-slate-900">{formatTHB(totalPrice)}</span>
+                                                </div>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            </div>
+                        ))}
+
+                        <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-right text-sm font-semibold text-emerald-700">
+                            Total {formatTHB(total)}
+                        </div>
+
+                        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                            <button
+                                type="button"
+                                className="inline-flex items-center justify-center rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-50"
+                                onClick={() => {
+                                    if (typeof window !== "undefined") {
+                                        window.localStorage.removeItem(CHECKOUT_DRAFT_KEY);
+                                    }
+                                    setDraft([]);
+                                }}
+                            >
+                                Clear draft
+                            </button>
+                            <button
+                                type="button"
+                                className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500 focus:outline-none focus:ring-4 focus:ring-emerald-100"
+                            >
+                                Place order (coming soon)
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </Layout>
+    );
+}

--- a/src/pages/web-hook-line.tsx
+++ b/src/pages/web-hook-line.tsx
@@ -5,8 +5,8 @@ import Layout from "@components/Layout";
 import { useRouter } from "next/router";
 import axios from "@utils/apiClient";
 import { useAppDispatch } from "@store/index";
-import { setTokens } from "@store/authSlice";
-import { saveTokens } from "@utils/tokenStorage";
+import {setTokens, setUser} from "@store/authSlice";
+import {saveTokens, saveUser} from "@utils/tokenStorage";
 import liff from "@line/liff";
 
 type Status = "boot" | "init" | "login" | "post" | "done" | "error";
@@ -47,8 +47,11 @@ export default function WebHookLinePage() {
                 if (!tokens.accessToken || !tokens.refreshToken) {
                     throw new Error("Server did not return tokens");
                 }
+                const user = r.data?.body?.user
                 dispatch(setTokens(tokens));
+                dispatch(setUser(user));
                 saveTokens(tokens);
+                saveUser(user);
                 setStatus("done");
                 router.replace("/");
             } catch (e: any) {

--- a/src/repository/config.ts
+++ b/src/repository/config.ts
@@ -14,3 +14,13 @@ export async function getConfigValue(name: string): Promise<string | null> {
 
     return data?.config_value ?? null;
 }
+
+export async function getNumberConfig(name: string, defaultValue: number): Promise<number> {
+    const raw = await getConfigValue(name);
+    if (raw == null) {
+        return defaultValue;
+    }
+
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : defaultValue;
+}

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,8 +1,9 @@
 // src/store/authSlice.ts
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import type { UserRecord } from "@/types";
 
-type State = { accessToken: string | null; refreshToken: string | null };
-const initialState: State = { accessToken: null, refreshToken: null };
+type State = { accessToken: string | null; refreshToken: string | null; user: UserRecord | null };
+const initialState: State = { accessToken: null, refreshToken: null, user: null };
 
 const slice = createSlice({
     name: "auth",
@@ -12,12 +13,16 @@ const slice = createSlice({
             state.accessToken = action.payload.accessToken;
             state.refreshToken = action.payload.refreshToken;
         },
+        setUser(state, action: PayloadAction<UserRecord | null>) {
+            state.user = action.payload ?? null;
+        },
         logout(state) {
             state.accessToken = null;
             state.refreshToken = null;
+            state.user = null;
         },
     },
 });
 
-export const { setTokens, logout } = slice.actions;
+export const { setTokens, setUser, logout } = slice.actions;
 export default slice.reducer;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,8 +25,8 @@ export type UserRecord = {
     email: string | null;
     phone: string | null;
     provider: string | null;
-    is_email_verified: boolean | null;
-    is_phone_verified: boolean | null;
+    is_email_verified: boolean ;
+    is_phone_verified: boolean ;
     card: CartBranchGroup[];
     created_at: string;
     updated_at: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,33 @@
+export type CartAddOn = {
+    name: string;
+    price: number;
+};
+
+export type CartItem = {
+    productId: string;
+    productName: string;
+    qty: number;
+    price: number;
+    productAddOns: CartAddOn[];
+};
+
+export type CartBranchGroup = {
+    branchId: string;
+    companyId: string;
+    branchName: string;
+    branchImage: string | null;
+    productList: CartItem[];
+};
+
+export type UserRecord = {
+    id: number;
+    firebase_uid: string;
+    email: string | null;
+    phone: string | null;
+    provider: string | null;
+    is_email_verified: boolean | null;
+    is_phone_verified: boolean | null;
+    card: CartBranchGroup[];
+    created_at: string;
+    updated_at: string;
+};

--- a/src/utils/cart.ts
+++ b/src/utils/cart.ts
@@ -1,0 +1,28 @@
+import type { CartAddOn, CartBranchGroup, CartItem } from "@/types";
+
+export function totalItemCount(card: CartBranchGroup[] | null | undefined): number {
+    if (!Array.isArray(card)) return 0;
+    return card.reduce((acc, group) => acc + (group.productList?.length ?? 0), 0);
+}
+
+export function totalQty(card: CartBranchGroup[] | null | undefined): number {
+    if (!Array.isArray(card)) return 0;
+    return card.reduce((acc, group) => {
+        const branchQty = (group.productList || []).reduce((sum, item) => sum + (item.qty ?? 0), 0);
+        return acc + branchQty;
+    }, 0);
+}
+
+export function canonicalizeAddOns(addOns: CartAddOn[]): string {
+    const sorted = [...(addOns || [])].sort((a, b) => {
+        if (a.name === b.name) {
+            return a.price - b.price;
+        }
+        return a.name.localeCompare(b.name);
+    });
+    return JSON.stringify(sorted);
+}
+
+export function buildCartItemKey(branchId: string, item: CartItem): string {
+    return `${branchId}|${item.productId}|${canonicalizeAddOns(item.productAddOns)}`;
+}

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -1,6 +1,9 @@
 // src/utils/tokenStorage.ts
+import type { UserRecord } from "@/types";
+
 export type StoredTokens = { accessToken: string; refreshToken: string };
 const KEY = "auth_tokens_v1";
+const USER_KEY = "APP_USER";
 
 export function saveTokens(tokens: StoredTokens) {
     if (typeof window === "undefined") return;
@@ -21,4 +24,26 @@ export function loadTokens(): StoredTokens | null {
 export function clearTokens() {
     if (typeof window === "undefined") return;
     localStorage.removeItem(KEY);
+}
+
+export function saveUser(user: UserRecord) {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(USER_KEY, JSON.stringify(user));
+}
+
+export function loadUser(): UserRecord | null {
+    if (typeof window === "undefined") return null;
+    const raw = localStorage.getItem(USER_KEY);
+    if (!raw) return null;
+    try {
+        const parsed = JSON.parse(raw) as UserRecord;
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+export function clearUser() {
+    if (typeof window === "undefined") return;
+    localStorage.removeItem(USER_KEY);
 }


### PR DESCRIPTION
## Summary
- update login and signup flows to return full user records with cart data and hydrate Redux/localStorage
- refactor /api/card/save to merge incoming items with per-item quantity caps and return the updated user
- add floating cart button, cart drawer with selection controls, and a checkout stub page using stored drafts

## Testing
- npm run test *(fails: Could not find '/workspace/delivery-food/.test-dist/tests')*

------
https://chatgpt.com/codex/tasks/task_e_68cfb0523b2c832faffa500a6f5bef91