### PR TITLE
Expose categories in search and surface user balance with language toggle

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import Navbar from "./Navbar";
 import FloatingCartButton from "@components/cart/FloatingCartButton";
 import CartDrawer from "@components/cart/CartDrawer";
 import NotificationCenter from "@components/notifications/NotificationCenter";
+import { FloatingLanguageToggle } from "@components/common";
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const [cartOpen, setCartOpen] = useState(false);
@@ -12,6 +13,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
             <Navbar />
             <NotificationCenter />
             <main className="px-4 py-8 sm:px-6 lg:px-8">{children}</main>
+            <FloatingLanguageToggle />
             <FloatingCartButton onClick={() => setCartOpen(true)} />
             <CartDrawer open={cartOpen} onClose={() => setCartOpen(false)} />
         </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { useSelector } from "react-redux";
-import LocaleSwitcher from "@/components/i18n/LocaleSwitcher";
 import { I18N_KEYS } from "@/constants/i18nKeys";
 import { useI18n } from "@/utils/i18n";
 import { formatTHB } from "@/utils/currency";
@@ -20,15 +19,16 @@ const Navbar: React.FC = () => {
                     {t(I18N_KEYS.BRAND_NAME)}
                 </Link>
                 <div className="flex items-center gap-3 text-sm text-slate-700">
+
+                    <Link href="/account" className="rounded-lg px-3 py-2 transition hover:bg-slate-100">
+                        {t(I18N_KEYS.NAV_ACCOUNT)}
+                    </Link>
+
                     {user && (
                         <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 shadow-sm">
                             {formattedBalance}
                         </span>
                     )}
-                    <LocaleSwitcher />
-                    <Link href="/account" className="rounded-lg px-3 py-2 transition hover:bg-slate-100">
-                        {t(I18N_KEYS.NAV_ACCOUNT)}
-                    </Link>
                 </div>
             </div>
         </nav>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,10 +1,17 @@
 import Link from "next/link";
+import { useSelector } from "react-redux";
 import LocaleSwitcher from "@/components/i18n/LocaleSwitcher";
 import { I18N_KEYS } from "@/constants/i18nKeys";
 import { useI18n } from "@/utils/i18n";
+import { formatTHB } from "@/utils/currency";
+import type { RootState } from "@/store";
 
 const Navbar: React.FC = () => {
     const { t } = useI18n();
+    const user = useSelector((state: RootState) => state.auth.user);
+
+    const balanceValue = typeof user?.balance === "number" ? user.balance : 0;
+    const formattedBalance = formatTHB(balanceValue);
 
     return (
         <nav className="border-b bg-white">
@@ -13,6 +20,11 @@ const Navbar: React.FC = () => {
                     {t(I18N_KEYS.BRAND_NAME)}
                 </Link>
                 <div className="flex items-center gap-3 text-sm text-slate-700">
+                    {user && (
+                        <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 shadow-sm">
+                            {formattedBalance}
+                        </span>
+                    )}
                     <LocaleSwitcher />
                     <Link href="/account" className="rounded-lg px-3 py-2 transition hover:bg-slate-100">
                         {t(I18N_KEYS.NAV_ACCOUNT)}

--- a/src/components/common/FloatingLanguageToggle.tsx
+++ b/src/components/common/FloatingLanguageToggle.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { I18N_KEYS } from "@/constants/i18nKeys";
+import { type Locale, useI18n } from "@/utils/i18n";
+
+const FloatingLanguageToggle: React.FC = () => {
+    const { locale, setLocale, t } = useI18n();
+
+    const handleChange = (nextLocale: Locale) => {
+        if (nextLocale === locale) return;
+        setLocale(nextLocale);
+    };
+
+    return (
+        <div className="fixed bottom-4 left-4 z-50">
+            <div className="rounded-2xl border border-slate-200 bg-white/95 px-3 py-2 shadow-lg backdrop-blur">
+                <span className="sr-only">{t(I18N_KEYS.LOCALE_SWITCHER_LABEL)}</span>
+                <div className="flex items-center gap-2">
+                    <button
+                        type="button"
+                        onClick={() => handleChange("th")}
+                        className={`min-w-[2.5rem] rounded-xl px-3 py-1 text-xs font-semibold transition focus:outline-none focus:ring-4 focus:ring-emerald-100 ${
+                            locale === "th"
+                                ? "bg-emerald-600 text-white shadow-sm"
+                                : "bg-white text-slate-600 hover:bg-emerald-50"
+                        }`}
+                        aria-pressed={locale === "th"}
+                    >
+                        TH
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => handleChange("en")}
+                        className={`min-w-[2.5rem] rounded-xl px-3 py-1 text-xs font-semibold transition focus:outline-none focus:ring-4 focus:ring-emerald-100 ${
+                            locale === "en"
+                                ? "bg-emerald-600 text-white shadow-sm"
+                                : "bg-white text-slate-600 hover:bg-emerald-50"
+                        }`}
+                        aria-pressed={locale === "en"}
+                    >
+                        EN
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default FloatingLanguageToggle;
+

--- a/src/components/common/FloatingLanguageToggle.tsx
+++ b/src/components/common/FloatingLanguageToggle.tsx
@@ -1,14 +1,27 @@
-import React from "react";
+import React, { useCallback } from "react";
+import { useRouter } from "next/router";
 import { I18N_KEYS } from "@/constants/i18nKeys";
 import { type Locale, useI18n } from "@/utils/i18n";
 
 const FloatingLanguageToggle: React.FC = () => {
+    const router = useRouter();
     const { locale, setLocale, t } = useI18n();
 
-    const handleChange = (nextLocale: Locale) => {
-        if (nextLocale === locale) return;
-        setLocale(nextLocale);
-    };
+    const handleChange = useCallback(
+        (nextLocale: Locale) => {
+            if (nextLocale === locale) return;
+            setLocale(nextLocale);
+            void router.replace(
+                {
+                    pathname: router.pathname,
+                    query: { ...router.query, lang: nextLocale },
+                },
+                undefined,
+                { shallow: true }
+            );
+        },
+        [locale, router, setLocale]
+    );
 
     return (
         <div className="fixed bottom-4 left-4 z-50">

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -8,3 +8,4 @@ export { default as AlertModal } from "./AlertModal";
 export type { AlertModalProps } from "./AlertModal";
 
 export { default as QuantityInput } from "./QuantityInput";
+export { default as FloatingLanguageToggle } from "./FloatingLanguageToggle";

--- a/src/pages/api/login.ts
+++ b/src/pages/api/login.ts
@@ -91,6 +91,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                     provider: freshUser?.provider ?? user.provider,
                     is_email_verified: freshUser?.is_email_verified ?? user.is_email_verified ?? null,
                     is_phone_verified: freshUser?.is_phone_verified ?? user.is_phone_verified ?? null,
+                    balance: freshUser?.balance ?? user.balance ?? 0,
                     card: freshUser?.card ?? [],
                     created_at: freshUser?.created_at ?? user.created_at,
                     updated_at: freshUser?.updated_at ?? user.updated_at,

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { searchBranches } from "@repository/branch";
+import { listAllCategories } from "@repository/categories";
 import { logError } from "@utils/logger";
 
 export const config = { runtime: "nodejs" };
@@ -70,6 +71,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
               })
             : enriched;
 
+        const categories = await listAllCategories();
+
         const branches = sorted.map((item) => ({
             id: item.branch_id,
             name: item.branch_name,
@@ -77,6 +80,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
             address_line: item.address_line ?? null,
             is_open: !item.is_force_closed,
             is_force_closed: item.is_force_closed,
+            open_hours: item.open_hours ?? null,
             distance_km:
                 typeof item.distance_m === "number" ? Number((item.distance_m / 1000).toFixed(2)) : null,
             products_sample: (item.products_sample ?? []).map((product) => ({
@@ -91,7 +95,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
             message: "success",
             body: {
                 branches,
-                categories: [],
+                categories,
             },
         });
     } catch (e: any) {

--- a/src/pages/api/signup.ts
+++ b/src/pages/api/signup.ts
@@ -113,6 +113,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                     provider: freshUser?.provider ?? user.provider,
                     is_email_verified: freshUser?.is_email_verified ?? user.is_email_verified ?? null,
                     is_phone_verified: freshUser?.is_phone_verified ?? user.is_phone_verified ?? null,
+                    balance: freshUser?.balance ?? user.balance ?? 0,
                     card: freshUser?.card ?? [],
                     created_at: freshUser?.created_at ?? user.created_at,
                     updated_at: freshUser?.updated_at ?? user.updated_at,

--- a/src/pages/api/user/me.ts
+++ b/src/pages/api/user/me.ts
@@ -37,6 +37,7 @@ export default withAuth(async function handler(req: NextApiRequest, res: NextApi
                     provider: user.provider,
                     is_email_verified: user.is_email_verified,
                     is_phone_verified: user.is_phone_verified,
+                    balance: user.balance,
                     card: user.card,
                     created_at: user.created_at,
                     updated_at: user.updated_at,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,70 +11,129 @@ import type { BranchItem, BranchSampleProduct, Category } from "@/components/sea
 import { useI18n } from "@/utils/i18n";
 import { I18N_KEYS } from "@/constants/i18nKeys";
 
-/** ---------- Normalizer to handle BOTH response shapes ---------- */
-function normalizeSearchPayload(payload: any): { branches: BranchItem[]; categories: Category[] } {
-    const body = payload?.body ?? payload?.data?.body ?? payload;
+type ApiBranchProduct = {
+    product_id: number;
+    name: string | null;
+    price: number | null;
+    image_url?: string | null;
+};
 
-    const rawBranches: any[] = Array.isArray(body)
-        ? body
-        : Array.isArray(body?.branches)
-            ? body.branches
-            : [];
+type ApiOpenHours = Record<string, [string, string][]>;
 
-    const rawCategories: any[] = Array.isArray(body?.categories) ? body.categories : [];
+type ApiBranchRecord = {
+    branch_id: number;
+    branch_name: string;
+    image_url?: string | null;
+    address_line?: string | null;
+    lat?: number | null;
+    lng?: number | null;
+    is_force_closed: boolean;
+    open_hours?: ApiOpenHours | null;
+    distance_m?: number | null;
+    products_sample?: ApiBranchProduct[];
+};
 
-    const branches: BranchItem[] = rawBranches
-        .map((b) => {
-            const id = b.id ?? b.branch_id;
-            const name = b.name ?? b.branch_name;
-            if (id == null || !name) return null;
+type ApiSearchResponse = {
+    code: string;
+    message: string;
+    body: {
+        branches: ApiBranchRecord[];
+        categories: { id: number; name: string }[];
+    };
+};
 
-            const distance_km =
-                typeof b.distance_km === "number"
-                    ? b.distance_km
-                    : typeof b.distance_m === "number"
-                        ? b.distance_m / 1000
-                        : null;
+const DAY_KEYS: Array<"sun" | "mon" | "tue" | "wed" | "thu" | "fri" | "sat"> = [
+    "sun",
+    "mon",
+    "tue",
+    "wed",
+    "thu",
+    "fri",
+    "sat",
+];
 
-            const is_force_closed = !!(b.is_force_closed ?? false);
-            const is_open = typeof b.is_open === "boolean" ? b.is_open : !is_force_closed;
+function hhmmToMinutes(hhmm: string): number {
+    const [hours, minutes] = hhmm.split(":").map((value) => Number.parseInt(value, 10));
+    if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+        return Number.NaN;
+    }
+    return (hours || 0) * 60 + (minutes || 0);
+}
 
-            const products_sample_raw = Array.isArray(b.products_sample) ? b.products_sample : [];
-            const products_sample: BranchSampleProduct[] = products_sample_raw
-                .map((p: any) => {
-                    const pid = p.id ?? p.product_id;
-                    if (pid == null) return null;
-                    return {
-                        id: pid,
-                        name: p.name,
-                        price: typeof p.price === "number" ? p.price : undefined,
-                        price_effective: typeof p.price_effective === "number" ? p.price_effective : undefined,
-                        image_url: p.image_url ?? null,
-                    } as BranchSampleProduct;
-                })
-                .filter(Boolean) as BranchSampleProduct[];
+function isOpenNow(openHours?: ApiOpenHours | null, isForceClosed?: boolean): boolean {
+    if (isForceClosed) return false;
+    if (!openHours) return true;
 
-            return {
-                id,
-                name,
-                image_url: b.image_url ?? null,
-                is_force_closed,
-                is_open,
-                distance_km,
-                address_line: b.address_line ?? null,
-                products_sample,
-            } as BranchItem;
-        })
-        .filter(Boolean) as BranchItem[];
+    const now = new Date();
+    const dayKey = DAY_KEYS[now.getDay()] ?? "sun";
+    const slots = openHours[dayKey];
+    if (!Array.isArray(slots) || slots.length === 0) {
+        return false;
+    }
 
-    const categories: Category[] = rawCategories
-        .map((c) => {
-            if (c?.id == null || !c?.name) return null;
-            return { id: c.id, name: c.name } as Category;
-        })
-        .filter(Boolean) as Category[];
+    const minutesNow = now.getHours() * 60 + now.getMinutes();
 
-    return { branches, categories };
+    return slots.some(([start, end]) => {
+        const startMinutes = hhmmToMinutes(start);
+        const endMinutes = hhmmToMinutes(end);
+        if (!Number.isFinite(startMinutes) || !Number.isFinite(endMinutes)) {
+            return false;
+        }
+
+        if (endMinutes < startMinutes) {
+            return minutesNow >= startMinutes || minutesNow <= endMinutes;
+        }
+
+        return minutesNow >= startMinutes && minutesNow <= endMinutes;
+    });
+}
+
+function mapBranchProduct(product: ApiBranchProduct): BranchSampleProduct | null {
+    if (!product || typeof product.product_id !== "number") {
+        return null;
+    }
+
+    return {
+        id: product.product_id,
+        name: product.name ?? "",
+        price: typeof product.price === "number" ? product.price : undefined,
+        image_url: product.image_url ?? null,
+    };
+}
+
+function mapBranchRecord(record: ApiBranchRecord): BranchItem | null {
+    if (!record || typeof record.branch_id !== "number" || !record.branch_name) {
+        return null;
+    }
+
+    const distanceKm =
+        typeof record.distance_m === "number"
+            ? Number((record.distance_m / 1000).toFixed(2))
+            : null;
+
+    const productsSample = Array.isArray(record.products_sample)
+        ? (record.products_sample.map(mapBranchProduct).filter(Boolean) as BranchSampleProduct[])
+        : [];
+
+    const computedIsOpen = isOpenNow(record.open_hours ?? null, record.is_force_closed);
+
+    return {
+        id: record.branch_id,
+        name: record.branch_name,
+        image_url: record.image_url ?? null,
+        address_line: record.address_line ?? null,
+        is_force_closed: record.is_force_closed,
+        is_open: computedIsOpen,
+        distance_km: distanceKm,
+        products_sample: productsSample,
+    };
+}
+
+function mapCategory(record: { id: number; name: string }): Category | null {
+    if (!record || typeof record.id !== "number" || !record.name) {
+        return null;
+    }
+    return { id: record.id, name: record.name };
 }
 
 /** ---------- Page ---------- */
@@ -111,7 +170,7 @@ const SearchPage: NextPage = () => {
         const runSearch = async () => {
             setLoading(true);
             try {
-                const { data } = await axios.get("/api/search", {
+                const { data } = await axios.get<ApiSearchResponse>("/api/search", {
                     params: {
                         q: submittedQuery,
                         categoryId: categoryId ?? undefined,
@@ -120,20 +179,30 @@ const SearchPage: NextPage = () => {
                     },
                 });
 
-                if (data?.code !== "OK") {
+                if (!data || data.code !== "OK" || !data.body) {
                     throw new Error(data?.message || t(I18N_KEYS.SEARCH_ERROR_DEFAULT));
                 }
 
-                const normalized = normalizeSearchPayload(data);
-                const sorted = normalized.branches.sort((a, b) => {
-                    const A = typeof a.distance_km === "number" ? a.distance_km : Number.POSITIVE_INFINITY;
-                    const B = typeof b.distance_km === "number" ? b.distance_km : Number.POSITIVE_INFINITY;
-                    return A - B;
+                const body = data.body;
+                const mappedCategories = Array.isArray(body.categories)
+                    ? (body.categories.map(mapCategory).filter(Boolean) as Category[])
+                    : [];
+
+                const mappedBranches = Array.isArray(body.branches)
+                    ? (body.branches.map(mapBranchRecord).filter(Boolean) as BranchItem[])
+                    : [];
+
+                const sorted = [...mappedBranches].sort((a, b) => {
+                    const distanceA =
+                        typeof a.distance_km === "number" ? a.distance_km : Number.POSITIVE_INFINITY;
+                    const distanceB =
+                        typeof b.distance_km === "number" ? b.distance_km : Number.POSITIVE_INFINITY;
+                    return distanceA - distanceB;
                 });
 
                 if (!ignore) {
                     setBranches(sorted);
-                    setCategories(normalized.categories);
+                    setCategories(mappedCategories);
                     setError(null);
                 }
             } catch (err: any) {

--- a/src/repository/categories.ts
+++ b/src/repository/categories.ts
@@ -1,0 +1,52 @@
+// src/repository/categories.ts
+import { getSupabase } from "@utils/supabaseServer";
+
+export type CategoryRow = {
+    id: number;
+    name: string;
+    is_enabled?: boolean | null;
+    is_active?: boolean | null;
+};
+
+export type CategoryRecord = { id: number; name: string };
+
+function normalizeCategory(row: CategoryRow): CategoryRecord | null {
+    if (row == null || !row.name) {
+        return null;
+    }
+
+    const id = typeof row.id === "number" ? row.id : Number(row.id);
+    if (!Number.isFinite(id)) {
+        return null;
+    }
+
+    if (typeof row.is_enabled === "boolean" && !row.is_enabled) {
+        return null;
+    }
+
+    if (typeof row.is_active === "boolean" && !row.is_active) {
+        return null;
+    }
+
+    return { id, name: row.name };
+}
+
+export async function listAllCategories(): Promise<CategoryRecord[]> {
+    const supabase = getSupabase();
+
+    const columns = "id, name, is_enabled, is_active";
+    const { data, error } = await supabase.from("tbl_category").select(columns);
+
+    let rows: CategoryRow[] | null = data as CategoryRow[] | null;
+
+    if (error) {
+        const fallback = await supabase.from("tbl_category").select("id, name");
+        if (fallback.error) {
+            throw new Error(fallback.error.message || "Failed to load categories");
+        }
+        rows = fallback.data as CategoryRow[] | null;
+    }
+
+    return (rows ?? []).map(normalizeCategory).filter((value): value is CategoryRecord => value !== null);
+}
+

--- a/src/repository/user.ts
+++ b/src/repository/user.ts
@@ -3,7 +3,7 @@ import { CartBranchGroup, UserRecord } from "@/types";
 import { getSupabase } from "@utils/supabaseServer";
 
 export const USER_SELECT =
-    "id, firebase_uid, email, phone, provider, is_email_verified, is_phone_verified, card, created_at, updated_at";
+    "id, firebase_uid, email, phone, provider, is_email_verified, is_phone_verified, balance, card, created_at, updated_at";
 
 function normalizeCard(input: unknown): CartBranchGroup[] {
     if (!Array.isArray(input)) {
@@ -29,6 +29,12 @@ function mapUser(row: any): UserRecord {
         provider: row.provider ?? null,
         is_email_verified: isEmailVerified,
         is_phone_verified: isPhoneVerified,
+        balance: (() => {
+            const raw = row.balance;
+            if (raw == null) return 0;
+            const parsed = typeof raw === "number" ? raw : Number(raw);
+            return Number.isFinite(parsed) ? parsed : 0;
+        })(),
         card: normalizeCard(row.card),
         created_at: String(row.created_at ?? new Date().toISOString()),
         updated_at: String(row.updated_at ?? new Date().toISOString()),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,7 @@ export type UserRecord = {
     provider: string | null;
     is_email_verified: boolean ;
     is_phone_verified: boolean ;
+    balance: number | null;
     card: CartBranchGroup[];
     created_at: string;
     updated_at: string;

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -7,7 +7,8 @@ export type Locale = "en" | "th";
 
 type Dictionary = Record<I18nKey, Record<Locale, string>>;
 
-const STORAGE_KEY = "locale";
+const STORAGE_KEY = "app.lang";
+const LEGACY_STORAGE_KEY = "locale";
 const DEFAULT_LOCALE: Locale = "en";
 const DICTIONARY = dictionary as Dictionary;
 
@@ -33,16 +34,23 @@ function resolveFromQuery(): Locale | null {
     const lang = normalizeLocale(params.get("lang"));
     if (!lang) return null;
     window.localStorage.setItem(STORAGE_KEY, lang);
+    window.localStorage.setItem(LEGACY_STORAGE_KEY, lang);
     updateDocumentLanguage(lang);
     return lang;
 }
 
 function resolveFromStorage(): Locale | null {
     if (typeof window === "undefined") return null;
-    const stored = normalizeLocale(window.localStorage.getItem(STORAGE_KEY));
-    if (stored) {
-        updateDocumentLanguage(stored);
-        return stored;
+    const storedPrimary = normalizeLocale(window.localStorage.getItem(STORAGE_KEY));
+    if (storedPrimary) {
+        updateDocumentLanguage(storedPrimary);
+        return storedPrimary;
+    }
+    const storedLegacy = normalizeLocale(window.localStorage.getItem(LEGACY_STORAGE_KEY));
+    if (storedLegacy) {
+        window.localStorage.setItem(STORAGE_KEY, storedLegacy);
+        updateDocumentLanguage(storedLegacy);
+        return storedLegacy;
     }
     return null;
 }
@@ -84,6 +92,7 @@ export function setLocale(locale: Locale) {
     cachedLocale = locale;
     if (typeof window !== "undefined") {
         window.localStorage.setItem(STORAGE_KEY, locale);
+        window.localStorage.setItem(LEGACY_STORAGE_KEY, locale);
     }
     updateDocumentLanguage(locale);
 }


### PR DESCRIPTION
## Summary
- add a categories repository and include categories plus open hours data in the /api/search response
- expand searchBranches matching to cover products, add-ons, branches, and companies while returning branch open_hours
- update the search UI to compute open state from open hours, populate category filters, show the user balance pill, and add a floating language toggle that persists locale

## Testing
- npm run lint
- npm test *(fails: Could not find '/workspace/delivery-food/.test-dist/tests')*

------
https://chatgpt.com/codex/tasks/task_e_68cffe1b3e5c832fa6774bf287dabac3